### PR TITLE
Add missing dummy ZeroScrap() on linux

### DIFF
--- a/BasiliskII/src/dummy/clip_dummy.cpp
+++ b/BasiliskII/src/dummy/clip_dummy.cpp
@@ -54,6 +54,14 @@ void GetScrap(void **handle, uint32 type, int32 offset)
 	D(bug("GetScrap handle %p, type %08x, offset %d\n", handle, type, offset));
 }
 
+/*
+ * ZeroScrap() is called before a Mac application writes to the clipboard; clears out the previous contents
+ */
+
+void ZeroScrap()
+{
+	D(bug("ZeroScrap\n"));
+}
 
 /*
  *  Mac application wrote to clipboard


### PR DESCRIPTION
/home/amade/workdir/macemu/SheepShaver/src/Unix/../emul_op.cpp:231: undefined reference to `ZeroScrap()'
collect2: ld returned 1 exit status
