### PR TITLE
Set tty raw mode when using a pty.

### DIFF
--- a/BasiliskII/src/Unix/serial_unix.cpp
+++ b/BasiliskII/src/Unix/serial_unix.cpp
@@ -222,7 +222,7 @@ int16 XSERDPort::open(uint16 config)
 	}
 
 	// Configure port for raw mode
-	if (protocol == serial) {
+	if (protocol == serial || protocol == pty) {
 		if (tcgetattr(fd, &mode) < 0)
 			goto open_error;
 		cfmakeraw(&mode);


### PR DESCRIPTION
This patch fixes the use of pty-based emulated serial devices (eg, https://mac68k.info/forums/message.jspa?messageID=333#333 )
