### PR TITLE
Work even if TRUE is undefined

### DIFF
--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -681,10 +681,10 @@ static bool init_sdl()
 
 #ifdef USE_SDL_VIDEO
 	// Don't let SDL block the screensaver
-	setenv("SDL_VIDEO_ALLOW_SCREENSAVER", "1", TRUE);
+	setenv("SDL_VIDEO_ALLOW_SCREENSAVER", "1", true);
 
 	// Make SDL pass through command-clicks and option-clicks unaltered
-	setenv("SDL_HAS3BUTTONMOUSE", "1", TRUE);
+	setenv("SDL_HAS3BUTTONMOUSE", "1", true);
 #endif
 
 	if (SDL_Init(sdl_flags) == -1) {


### PR DESCRIPTION
Compiling on Ubuntu 12.10 with flags:

```
CC=gcc-4.5 CXX=g++-4.5 ./configure --enable-sdl-video --enable-sdl-audio --without-gtk --without-esd --enable-jit
```

fails with the error:

```
main_unix.cpp: In function ‘bool init_sdl()’:
main_unix.cpp:684:45: error: ‘TRUE’ was not declared in this scope
```

This happens because TRUE is undefined in these lines of code:

```
#ifdef USE_SDL_VIDEO
    // Don't let SDL block the screensaver
    setenv("SDL_VIDEO_ALLOW_SCREENSAVER", "1", TRUE);

    // Make SDL pass through command-clicks and option-clicks unaltered
    setenv("SDL_HAS3BUTTONMOUSE", "1", TRUE);
#endif
```

Switching to use `true` instead of `TRUE` works fine.
