### PR TITLE
Standalone GUI doesn't need to pull in all the generic disks

### DIFF
--- a/BasiliskII/src/Unix/sys_unix.cpp
+++ b/BasiliskII/src/Unix/sys_unix.cpp
@@ -68,9 +68,11 @@
 #include "debug.h"
 
 static disk_factory *disk_factories[] = {
+#ifndef STANDALONE_GUI
 	disk_sparsebundle_factory,
 #if defined(HAVE_LIBVHD)
 	disk_vhd_factory,
+#endif
 #endif
 	NULL
 };


### PR DESCRIPTION
A regression from my generic disk code makes the standalone GUI fail to compile. It pulls in sys_unix.cpp just for SysAddSerialPrefs(), which then wants disk_sparsebundle_factory() and friends.

It's rather silly to include disk_sparsebundle.cpp in just to satisfy that. So my preferred fix is to just #ifdef out the factory functions if we're building standalone. Sound ok?
