### PR TITLE
Update SheepShaverLauncher for modern XCode and OS X

### DIFF
--- a/SheepShaver/src/MacOSX/Launcher/SheepShaverLauncher.xcodeproj/project.pbxproj
+++ b/SheepShaver/src/MacOSX/Launcher/SheepShaverLauncher.xcodeproj/project.pbxproj
@@ -328,7 +328,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Debug;
 		};
@@ -336,11 +335,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREFIX_HEADER = LauncherPrefix.h;
-				GCC_VERSION = 4.0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Release;
 		};

--- a/SheepShaver/src/MacOSX/Launcher/VMListController.h
+++ b/SheepShaver/src/MacOSX/Launcher/VMListController.h
@@ -20,7 +20,11 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface VMListController : NSWindowController {
+@interface VMListController : NSWindowController
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+    <NSTableViewDataSource, NSTableViewDelegate>
+#endif
+{
 	IBOutlet NSTableView *vmList;
 	IBOutlet NSButton *newButton;
 	IBOutlet NSButton *importButton;

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.h
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.h
@@ -21,6 +21,9 @@
 #import <Cocoa/Cocoa.h>
 
 @interface VMSettingsController : NSWindowController
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+    <NSTableViewDataSource>
+#endif
 {
     BOOL cancelWasClicked;
 


### PR DESCRIPTION
Minor fixes to allow SheepShaverLauncher to compile out-of-the--box on the 10.6 SDK and XCode 4.x. I don't anticipate the changes breaking earlier versions, though I have not been able to test.
