### PR TITLE
Make the standalone GUI build on Linux again

### DIFF
--- a/SheepShaver/src/Unix/Makefile.in
+++ b/SheepShaver/src/Unix/Makefile.in
@@ -46,7 +46,8 @@ STANDALONE_GUI = @STANDALONE_GUI@
 GUI_CFLAGS = @GUI_CFLAGS@
 GUI_LIBS = @GUI_LIBS@
 GUI_SRCS = ../prefs.cpp prefs_unix.cpp prefs_editor_gtk.cpp ../prefs_items.cpp \
-	../user_strings.cpp user_strings_unix.cpp xpram_unix.cpp sys_unix.cpp rpc_unix.cpp
+	../user_strings.cpp user_strings_unix.cpp xpram_unix.cpp sys_unix.cpp rpc_unix.cpp \
+	../dummy/prefs_dummy.cpp
 
 # Append disassembler to dyngen, if available
 ifneq (:no,$(MONSRCS):$(USE_DYNGEN))

--- a/SheepShaver/src/Unix/prefs_editor_gtk.cpp
+++ b/SheepShaver/src/Unix/prefs_editor_gtk.cpp
@@ -1493,7 +1493,7 @@ int main(int argc, char *argv[])
 	gtk_init(&argc, &argv);
 
 	// Read preferences
-	PrefsInit(argc, argv);
+	PrefsInit(0, argc, argv);
 
 	// Show preferences editor
 	bool start = PrefsEditor();


### PR DESCRIPTION
Fix some bit-rot.
- prefs_exit() and prefs_init() need to be included in the standalone GUI
- PrefsInit() has three arguments
