### PR TITLE
Buildfix

### DIFF
--- a/BasiliskII/src/Unix/Makefile.in
+++ b/BasiliskII/src/Unix/Makefile.in
@@ -168,7 +168,6 @@ mostlyclean:
 
 clean: mostlyclean
 	rm -f cpuemu.cpp cpudefs.cpp cputmp*.s cpufast*.s cpustbl.cpp cputbl.h compemu.cpp compstbl.cpp comptbl.h
-	rm -rf etherslavetool.dSYM
 
 distclean: clean
 	rm -rf $(OBJ_DIR)


### PR DESCRIPTION
Fixes Unix build for OS X 10.8.3.
