### PR TITLE
New video fix

### DIFF
--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -1637,6 +1637,12 @@ bool VideoInit(bool classic)
 		return false;
 	}
 	std::sort(avail_depths, avail_depths + num_depths);
+
+#ifdef __APPLE__
+	// 15-bit color does not seem to work on OS X
+	int *last = std::remove(avail_depths, avail_depths + num_depths, 15);
+	num_depths = ( (size_t)last - (size_t)avail_depths ) / sizeof(int);
+#endif
 	
 #ifdef ENABLE_FBDEV_DGA
 	// Frame buffer name


### PR DESCRIPTION
This is a simpler way to fix the OS X video.  The only mode that does not work under OS X is 16-bit color mode.
