### PR TITLE
Remove 15 bit video for OS X.  This mode doesn't seem to work.

### DIFF
--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -1636,13 +1636,12 @@ bool VideoInit(bool classic)
 		ErrorAlert(STR_UNSUPP_DEPTH_ERR);
 		return false;
 	}
-	std::sort(avail_depths, avail_depths + num_depths);
 
-#ifdef __APPLE__
 	// 15-bit color does not seem to work on OS X
-	int *last = std::remove(avail_depths, avail_depths + num_depths, 15);
-	num_depths = ( (size_t)last - (size_t)avail_depths ) / sizeof(int);
-#endif
+	int *list_end = std::remove(avail_depths, avail_depths + num_depths, 
+				    15);
+	num_depths = list_end - avail_depths;
+	std::sort(avail_depths, avail_depths + num_depths);
 	
 #ifdef ENABLE_FBDEV_DGA
 	// Frame buffer name


### PR DESCRIPTION
This also fixes 2-bit, 4-bit, and 8-bit modes.
