### PR TITLE
FreeBSD/amd64

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -112,7 +112,7 @@ case "$target_cpu" in
   m68k* ) HAVE_M68K=yes;;
   sparc* ) HAVE_SPARC=yes;;
   powerpc* ) HAVE_POWERPC=yes;;
-  x86_64* ) HAVE_X86_64=yes;;
+  x86_64* | amd64* ) HAVE_X86_64=yes;;
 esac
 
 dnl Check if we should really be assuming x86_64 even if we detected HAVE_I386 above.
@@ -508,6 +508,9 @@ mips-sony-bsd|mips-sony-newsos4)
 	no_dev_ptmx=1
 	;;
 *-*-darwin*)
+	no_dev_ptmx=1
+	;;
+*-*-freebsd*)
 	no_dev_ptmx=1
 	;;
 esac

--- a/BasiliskII/src/Unix/sigsegv.cpp
+++ b/BasiliskII/src/Unix/sigsegv.cpp
@@ -243,9 +243,7 @@ static void powerpc_decode_instruction(instruction_t *instruction, unsigned int 
 
 #if HAVE_SIGINFO_T
 // Generic extended signal handler
-#if defined(__FreeBSD__)
-#define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGBUS)
-#elif defined(__hpux)
+#if defined(__hpux)
 #define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGSEGV) FAULT_HANDLER(SIGBUS)
 #else
 #define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGSEGV)
@@ -285,8 +283,14 @@ static void powerpc_decode_instruction(instruction_t *instruction, unsigned int 
 #endif
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
 #if (defined(i386) || defined(__i386__))
+#undef SIGSEGV_ALL_SIGNALS
+#define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGBUS)
 #define SIGSEGV_FAULT_INSTRUCTION		(((struct sigcontext *)scp)->sc_eip)
 #define SIGSEGV_REGISTER_FILE			((SIGSEGV_REGISTER_TYPE *)&(((struct sigcontext *)scp)->sc_edi)) /* EDI is the first GPR (even below EIP) in sigcontext */
+#define SIGSEGV_SKIP_INSTRUCTION		ix86_skip_instruction
+#elif (defined(x86_64) || defined(__x86_64__))
+#define SIGSEGV_FAULT_INSTRUCTION		(((struct sigcontext *)scp)->sc_rip)
+#define SIGSEGV_REGISTER_FILE			((SIGSEGV_REGISTER_TYPE *)&(((struct sigcontext *)scp)->sc_rdi))
 #define SIGSEGV_SKIP_INSTRUCTION		ix86_skip_instruction
 #endif
 #endif
@@ -804,6 +808,25 @@ enum {
 	X86_REG_EBP = 2,
 	X86_REG_ESI = 1,
 	X86_REG_EDI = 0
+#endif
+#if (defined(x86_64) || defined(__x86_64__))
+	X86_REG_EDI = 0,
+	X86_REG_ESI = 1,
+	X86_REG_EDX = 2,
+	X86_REG_ECX = 3,
+	X86_REG_R8  = 4,
+	X86_REG_R9  = 5,
+	X86_REG_EAX = 6,
+	X86_REG_EBX = 7,
+	X86_REG_EBP = 8,
+	X86_REG_R10 = 9,
+	X86_REG_R11 = 10,
+	X86_REG_R12 = 11,
+	X86_REG_R13 = 12,
+	X86_REG_R14 = 13,
+	X86_REG_R15 = 14,
+	X86_REG_EIP = 19,
+	X86_REG_ESP = 22,
 #endif
 };
 #endif

--- a/BasiliskII/src/Unix/vm_alloc.cpp
+++ b/BasiliskII/src/Unix/vm_alloc.cpp
@@ -71,6 +71,11 @@ typedef unsigned long vm_uintptr_t;
 #ifndef MAP_32BIT
 #define MAP_32BIT 0
 #endif
+#ifdef __FreeBSD__
+#define FORCE_MAP_32BIT MAP_FIXED
+#else
+#define FORCE_MAP_32BIT MAP_32BIT
+#endif
 #ifndef MAP_ANON
 #define MAP_ANON 0
 #endif
@@ -81,7 +86,7 @@ typedef unsigned long vm_uintptr_t;
 #define MAP_EXTRA_FLAGS (MAP_32BIT)
 
 #ifdef HAVE_MMAP_VM
-#if (defined(__linux__) && defined(__i386__)) || HAVE_LINKER_SCRIPT
+#if (defined(__linux__) && defined(__i386__)) || defined(__FreeBSD__) || HAVE_LINKER_SCRIPT
 /* Force a reasonnable address below 0x80000000 on x86 so that we
    don't get addresses above when the program is run on AMD64.
    NOTE: this is empirically determined on Linux/x86.  */
@@ -117,7 +122,7 @@ static int translate_map_flags(int vm_flags)
 	if (vm_flags & VM_MAP_FIXED)
 		flags |= MAP_FIXED;
 	if (vm_flags & VM_MAP_32BIT)
-		flags |= MAP_32BIT;
+		flags |= FORCE_MAP_32BIT;
 	return flags;
 }
 #endif

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -484,6 +484,9 @@ mips-sony-bsd|mips-sony-newsos4)
 *-*-darwin*)
 	no_dev_ptmx=1
 	;;
+*-*-freebsd*)
+	no_dev_ptmx=1
+	;;
 esac
 
 if test -z "$no_dev_ptmx" ; then

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -90,6 +90,7 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>
+#include <sys/param.h>
 #include <signal.h>
 
 #include "sysdeps.h"

--- a/SheepShaver/src/Unix/sysdeps.h
+++ b/SheepShaver/src/Unix/sysdeps.h
@@ -69,7 +69,7 @@
 #endif
 
 // Fix offsetof() on FreeBSD and GCC >= 3.4
-#if defined(__FreeBSD__) && defined(__cplusplus)
+#if defined(__FreeBSD__) && defined(__cplusplus) && __GNUC__ < 4
 #undef offsetof
 /* The cast to "char &" below avoids problems with user-defined
    "operator &", which can appear in a POD type.  */


### PR DESCRIPTION
Currently the macemu projects don't even compile on FreeBSD/amd64. This patch allows BasiliskII to compile and run well.

SheepShaver compiles ok with these fixups, but doesn't run successfully. It can't allocate low-memory in real-addressing mode, but I'm not sure why, since vmparam.h in the kernel has VM_MIN_ADDRESS set to zero. In direct-addressing mode, it SEGVs, and I haven't looked into it further. I should probably first check whether FreeBSD/i386 works, and whether direct-addressing works on other platforms.
