### PR TITLE
SheepShaver on FreeBSD

### DIFF
--- a/BasiliskII/src/Unix/sigsegv.cpp
+++ b/BasiliskII/src/Unix/sigsegv.cpp
@@ -243,7 +243,7 @@ static void powerpc_decode_instruction(instruction_t *instruction, unsigned int 
 
 #if HAVE_SIGINFO_T
 // Generic extended signal handler
-#if defined(__hpux)
+#if defined(__hpux) || defined(__FreeBSD__)
 #define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGSEGV) FAULT_HANDLER(SIGBUS)
 #else
 #define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGSEGV)
@@ -283,8 +283,6 @@ static void powerpc_decode_instruction(instruction_t *instruction, unsigned int 
 #endif
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
 #if (defined(i386) || defined(__i386__))
-#undef SIGSEGV_ALL_SIGNALS
-#define SIGSEGV_ALL_SIGNALS				FAULT_HANDLER(SIGBUS)
 #define SIGSEGV_FAULT_INSTRUCTION		(((struct sigcontext *)scp)->sc_eip)
 #define SIGSEGV_REGISTER_FILE			((SIGSEGV_REGISTER_TYPE *)&(((struct sigcontext *)scp)->sc_edi)) /* EDI is the first GPR (even below EIP) in sigcontext */
 #define SIGSEGV_SKIP_INSTRUCTION		ix86_skip_instruction

--- a/BasiliskII/src/Unix/vm_alloc.cpp
+++ b/BasiliskII/src/Unix/vm_alloc.cpp
@@ -259,7 +259,8 @@ void * vm_acquire(size_t size, int options)
 	if (sizeof(void *) == 8 && (options & VM_MAP_32BIT) && !((char *)addr <= (char *)0xffffffff))
 		return VM_MAP_FAILED;
 
-	next_address = (char *)addr + size;
+	if ((unsigned long long)addr < 0xffffffffULL)
+		next_address = (char *)addr + size;
 #elif defined(HAVE_WIN32_VM)
 	int alloc_type = MEM_RESERVE | MEM_COMMIT;
 	if (options & VM_MAP_WRITE_WATCH)

--- a/BasiliskII/src/uae_cpu/compiler/compemu_support.cpp
+++ b/BasiliskII/src/uae_cpu/compiler/compemu_support.cpp
@@ -5719,7 +5719,7 @@ static uint8 *do_alloc_code(uint32 size, int depth)
 
 	return do_alloc_code(size, depth + 1);
 #else
-	uint8 *code = (uint8 *)vm_acquire(size);
+	uint8 *code = (uint8 *)vm_acquire(size, VM_MAP_32BIT);
 	return code == VM_MAP_FAILED ? NULL : code;
 #endif
 }

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -1498,7 +1498,7 @@ if [[ "x$EMULATED_PPC" = "xyes" ]]; then
       powerpc:elf)
         ac_cv_use_dyngen=yes
         ;;
-      x86_64:elf)
+      x86_64:elf|amd64:elf)
         ac_cv_use_dyngen=yes
         ;;
       i?86:elf)

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -341,7 +341,7 @@ int atomic_or(int *var, int v)
 
 static inline uint8 *vm_mac_acquire(uint32 size)
 {
-	return (uint8 *)vm_acquire(size);
+	return (uint8 *)vm_acquire(size, VM_MAP_32BIT);
 }
 
 static inline int vm_mac_acquire_fixed(uint32 addr, uint32 size)


### PR DESCRIPTION
It's working on FreeBSD i386 and amd64, with and without the JIT! Note that in FreeBSD 9.0 and higher one needs the sysctl "security.bsd.map_at_zero=1" to allow mapping low memory.

I don't anticipate this causing problems for other platforms, but I only checked on OS X so far. Please look over the changes to make sure they're sane :)
