### PR TITLE
Mac: Allow selecting bundles in the disk prefs

### DIFF
--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -211,7 +211,7 @@ static NSString *makeRelativeIfNecessary(NSString *path)
 - (IBAction) addDisk: (id) sender
 {
   NSOpenPanel *open = [NSOpenPanel openPanel];
-  [open setCanChooseDirectories:NO];
+  [open setCanChooseDirectories:YES];
   [open setAllowsMultipleSelection:NO];
   [open setTreatsFilePackagesAsDirectories:YES];
   [open beginSheetForDirectory: [[NSFileManager defaultManager] currentDirectoryPath]


### PR DESCRIPTION
Users should be able to select sparsebundles in the disk prefs, but should
still be able to navigate inside .sheepvm bundles.

See https://github.com/cebix/macemu/pull/25#issuecomment-15900806
