### PR TITLE
Change GUI object extension, so GCC doesn't think we're Go

### DIFF
--- a/BasiliskII/src/Unix/Makefile.in
+++ b/BasiliskII/src/Unix/Makefile.in
@@ -93,7 +93,7 @@ OBJS := $(SRCS_LIST_TO_OBJS)
 SRCS := $(SRCS:%=@top_srcdir@/%)
 
 define GUI_SRCS_LIST_TO_OBJS
-	$(addprefix $(OBJ_DIR)/, $(addsuffix .go, $(foreach file, $(GUI_SRCS), \
+	$(addprefix $(OBJ_DIR)/, $(addsuffix .guio, $(foreach file, $(GUI_SRCS), \
 	$(basename $(notdir $(file))))))
 endef
 GUI_OBJS = $(GUI_SRCS_LIST_TO_OBJS)
@@ -193,7 +193,7 @@ $(OBJ_DIR)/%.o : %.mm
 	$(CXX) $(CPPFLAGS) $(DEFS) $(CXXFLAGS) -c $< -o $@
 $(OBJ_DIR)/%.o : %.s
 	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) -c $< -o $@
-$(OBJ_DIR)/%.go : %.cpp
+$(OBJ_DIR)/%.guio : %.cpp
 	$(CXX) $(CPPFLAGS) $(DEFS) $(CXXFLAGS) $(GUI_CFLAGS) -DSTANDALONE_GUI -c $< -o $@
 
 # Windows resources

--- a/SheepShaver/src/Unix/Makefile.in
+++ b/SheepShaver/src/Unix/Makefile.in
@@ -97,7 +97,7 @@ endef
 OBJS = $(SRCS_LIST_TO_OBJS)
 
 define GUI_SRCS_LIST_TO_OBJS
-	$(addprefix $(OBJ_DIR)/, $(addsuffix .go, $(foreach file, $(GUI_SRCS), \
+	$(addprefix $(OBJ_DIR)/, $(addsuffix .guio, $(foreach file, $(GUI_SRCS), \
 	$(basename $(notdir $(file))))))
 endef
 GUI_OBJS = $(GUI_SRCS_LIST_TO_OBJS)
@@ -195,7 +195,7 @@ $(OBJ_DIR)/%.o : %.S
 	$(CPP) $(CPPFLAGS) -D__ASSEMBLY__ $< -o $*.out.s
 	$(AS) $(ASFLAGS) -o $@ $*.out.s
 	rm $*.out.s
-$(OBJ_DIR)/%.go : %.cpp
+$(OBJ_DIR)/%.guio : %.cpp
 	$(CXX) $(CPPFLAGS) $(DEFS) $(CXXFLAGS) $(GUI_CFLAGS) -DSTANDALONE_GUI -c $< -o $@
 
 # Kheperix CPU emulator


### PR DESCRIPTION
We're current using ".go" to indicate an object file destined for the standalone GUI. Recent GCC has a compiler for the Go language, which thinks .go is a Go program. Change it to ".guio" so it compiles correctly.
