### PR TITLE
temporarily disable forking causing basiliskii to hang

### DIFF
--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -489,7 +489,7 @@ int main(int argc, char **argv)
 
 #if defined(ENABLE_XF86_DGA) && !defined(ENABLE_MON)
 	// Fork out, so we can return from fullscreen mode when things get ugly
-	XF86DGAForkApp(DefaultScreen(x_display));
+//	XF86DGAForkApp(DefaultScreen(x_display));
 #endif
 #endif
 


### PR DESCRIPTION
When forking out is enabled basiliskii hangs on ubuntu 14.04 systems. It would be caused by forking after gtk_init() is called, see https://bugs.launchpad.net/ubuntu/+source/xfce4-volumed/+bug/1347272. After disabling XF86DGAForkApp basiliskii no longer hangs. Can you adapt the code so forking happens before calling gtk_init()?
