### PR TITLE
Tap update for modern linux versions

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -825,6 +825,7 @@ dnl Check that the host supports TUN/TAP devices
 AC_CACHE_CHECK([whether TUN/TAP is supported],
   ac_cv_tun_tap_support, [
   AC_TRY_COMPILE([
+    #include <sys/socket.h>
     #if defined(HAVE_LINUX_IF_H) && defined(HAVE_LINUX_IF_TUN_H)
     #include <linux/if.h>
     #include <linux/if_tun.h>

--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -489,7 +489,7 @@ int main(int argc, char **argv)
 
 #if defined(ENABLE_XF86_DGA) && !defined(ENABLE_MON)
 	// Fork out, so we can return from fullscreen mode when things get ugly
-	XF86DGAForkApp(DefaultScreen(x_display));
+//	XF86DGAForkApp(DefaultScreen(x_display));
 #endif
 #endif
 

--- a/BasiliskII/src/Unix/tunconfig
+++ b/BasiliskII/src/Unix/tunconfig
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 ###########################################################################
 # Configuration of the tunN devices for usage with Basilisk II.
 # (derived MOL tunconfig script)
@@ -18,7 +19,7 @@
 ###########################################################################
 
 SUDO=/usr/bin/sudo
-IFCONFIG=/sbin/ifconfig
+IP=/sbin/ip
 IPTABLES=/sbin/iptables
 
 #########################################################
@@ -28,13 +29,14 @@ IPTABLES=/sbin/iptables
     shift 1
 }
 
-TUN_DEV=$1
+TAP_DEV=$1
 ACTION=$2
 
-TUN_NUM=`echo $TUN_DEV | sed s/[^0-9]//g`
-NET_NUM=`expr 40 + $TUN_NUM`
-TUN_NET=172.20.$NET_NUM.0/24
-TUN_HOST=172.20.$NET_NUM.1
+TAP_NUM=`echo $TAP_DEV | sed s/[^0-9]//g`
+NET_NUM=`expr 40 + $TAP_NUM`
+TAP_NET=172.20.$NET_NUM.0/24
+TAP_HOST=172.20.$NET_NUM.1/24
+USER_ID=`id -u`
 
 #########################################################
 # Misc Checks
@@ -45,7 +47,7 @@ TUN_HOST=172.20.$NET_NUM.1
     exit 2
 }
 
-[[ "`id -u`" = "0" ]] && {
+[[ "$USER_ID" = "0" ]] && {
     echo "---> $SUDO not necessary." 1>&2
     SUDO=""
 }
@@ -56,15 +58,15 @@ TUN_HOST=172.20.$NET_NUM.1
 }
 
 if [ -n "$SUDO" ]; then
-    $SUDO -l | grep -q "NOPASSWD: $IFCONFIG" || {
-        echo "---> Missing sudo NOPASSWD: $IFCONFIG." 1>&2
+    $SUDO -l | grep -q "NOPASSWD: $IP" || {
+        echo "---> Missing sudo NOPASSWD: $IP." 1>&2
         exit 1
     }
     $SUDO -l | grep -q "NOPASSWD: $IPTABLES" || {
         echo "---> Missing sudo NOPASSWD: $IPTABLES." 1>&2
         exit 1
     }
-    IFCONFIG="$SUDO $IFCONFIG"
+    IP="$SUDO $IP"
     IPTABLES="$SUDO $IPTABLES"
 fi
 
@@ -77,7 +79,7 @@ $IPTABLES -L -n -t nat > /dev/null || exit 1
 #########################################################
 
 {
-    $IPTABLES -t nat -D POSTROUTING -s $TUN_NET -d ! $TUN_NET -j MASQUERADE
+    $IPTABLES -t nat -D POSTROUTING -s $TAP_NET ! -d $TAP_NET -j MASQUERADE
 } >& /dev/null
 
 #########################################################
@@ -85,7 +87,7 @@ $IPTABLES -L -n -t nat > /dev/null || exit 1
 #########################################################
 
 [[ "$ACTION" = down ]] && {
-    $IFCONFIG $TUN_DEV down
+    $IP tuntap del $TAP_DEV mode tap
 }
 
 #########################################################
@@ -93,10 +95,12 @@ $IPTABLES -L -n -t nat > /dev/null || exit 1
 #########################################################
 
 [[ "$ACTION" = up ]] && {
-    $IFCONFIG $TUN_DEV $TUN_HOST
-
+    $IP tuntap add $TAP_DEV mode tap user $USER_ID
+    $IP addr add $TAP_HOST dev $TAP_DEV
+    $IP link set $TAP_DEV up
     # masquerade the tun network
-    $IPTABLES -t nat -A POSTROUTING -s $TUN_NET -d ! $TUN_NET -j MASQUERADE
+    $IPTABLES -t nat -A POSTROUTING -s $TAP_NET ! -d $TAP_NET -j MASQUERADE
 }
 
 exit 0
+

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -815,7 +815,7 @@ int main(int argc, char **argv)
 
 #if defined(ENABLE_XF86_DGA) && !defined(ENABLE_MON)
 	// Fork out, so we can return from fullscreen mode when things get ugly
-	XF86DGAForkApp(DefaultScreen(x_display));
+	//XF86DGAForkApp(DefaultScreen(x_display));
 #endif
 #endif
 


### PR DESCRIPTION
This pull request re-enables the tap interface for modern linux versions
- when tuntap is detected in the configure script ethertap is no longer used and the user can enter tapN as ether device
- tunconfig (which should be renamed tapconfig IMO) is updated to use ip instead of ifconfig and now creates a tap device which has the current user as owner
- This pull request contains the temporarily disabled fork

http://backreference.org/2010/03/26/tuntap-interface-tutorial/ has been extremely useful
