### PR TITLE
fixes for sheep_net kernel panic and memory leak

### DIFF
--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -425,6 +425,11 @@ static ssize_t sheep_net_read(struct file *f, char *buf, size_t count, loff_t *o
  *  Driver write() function
  */
 
+static inline void do_nothing(struct sk_buff *skb)
+{
+	return;
+}
+
 static ssize_t sheep_net_write(struct file *f, const char *buf, size_t count, loff_t *off)
 {
 	struct SheepVars *v = (struct SheepVars *)f->private_data;
@@ -498,6 +503,7 @@ static ssize_t sheep_net_write(struct file *f, const char *buf, size_t count, lo
 	/* Outgoing packet (will be on the net) */
 	demasquerade(v, skb);
 
+	skb->destructor = do_nothing;
 	skb->protocol = PROT_MAGIC;	/* Magic value (we can recognize the packet in sheep_net_receiver) */
 	dev_queue_xmit(skb);
 	return count;

--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -462,7 +462,10 @@ static ssize_t sheep_net_write(struct file *f, const char *buf, size_t count, lo
 	}
 
 	/* Transmit packet */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0)
+	/* XXX: unsure which version needs this */
 	atomic_add(skb->truesize, &v->skt->wmem_alloc);
+#endif
 	skb->sk = v->skt;
 	skb->dev = v->ether;
 	skb->priority = 0;

--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -462,8 +462,7 @@ static ssize_t sheep_net_write(struct file *f, const char *buf, size_t count, lo
 	}
 
 	/* Transmit packet */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0)
-	/* XXX: unsure which version needs this */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,31)
 	atomic_add(skb->truesize, &v->skt->wmem_alloc);
 #endif
 	skb->sk = v->skt;


### PR DESCRIPTION
Fixed Linux kernel panic when using sheep_net with n2n edge0 tap device: tun_net_xmit invokes skb->destructor which is null. An empty destructor fixes the problem.

Fixed memory leak reported by kmemleak. Subsequently sheep_net is removable again with rmmod.