### PR TITLE
fix sheep_net kernel panic when combined with Linux AppleTalk module

### DIFF
--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -489,6 +489,7 @@ static ssize_t sheep_net_write(struct file *f, const char *buf, size_t count, lo
 
 	/* Is this packet addressed solely to the local host? */
 	if (is_local_addr(v, skb->data) && !(skb->data[0] & ETH_ADDR_MULTICAST)) {
+		skb->destructor = do_nothing;
 		skb->protocol = eth_type_trans(skb, v->ether);
 		netif_rx(skb);
 		return count;


### PR DESCRIPTION
So I wanted to see AppleTalk Zones in the Chooser, I configured netatalk atalkd as a router between two dummy interfaces, launched a SheepShaver attached to each dummy, and Linux panicked because an skb was missing a destructor.

Relevant excerpt from the log:
```
[  451.431056] kernel BUG at /build/buildd/linux-3.13.0/include/linux/skbuff.h:1859!
[  451.432059] Modules linked in: sheep_net(OX) dummy appletalk psnap llc 
[  451.432059] CPU: 0 PID: 1714 Comm: SheepShaver Tainted: G           OX 3.13.0-54-generic #91-Ubuntu
[  451.432059] Call Trace:
[  451.432059]  <IRQ> 
[  451.432059]  [<ffffffff81613921>] sock_queue_rcv_skb+0x181/0x220
[  451.432059]  [<ffffffffa00bcfc0>] atalk_rcv+0x260/0x4a0 [appletalk]
[  451.432059]  [<ffffffffa00b1244>] snap_rcv+0x74/0xb1 [psnap]
[  451.432059]  [<ffffffffa009c51e>] llc_rcv+0x29e/0x370 [llc]
[  451.432059]  [<ffffffff8108f1de>] ? hrtimer_interrupt+0x1ee/0x230
[  451.432059]  [<ffffffff81626fe6>] __netif_receive_skb_core+0x666/0x840
[  451.432059]  [<ffffffff816271d8>] __netif_receive_skb+0x18/0x60
```