### PR TITLE
Build on Mac OS X 10.10+

### DIFF
--- a/BasiliskII/src/Unix/Darwin/lowmem.c
+++ b/BasiliskII/src/Unix/Darwin/lowmem.c
@@ -72,6 +72,11 @@ void pagezero_32(struct mach_header *machhead)
 	/* change the permissions */
 	sc_cmd->maxprot = target_uint32(VM_PROT_ALL);
 	sc_cmd->initprot = target_uint32(VM_PROT_ALL);
+
+#ifdef MH_PIE
+	/* disable pie in header */
+	machhead->flags = target_uint32(target_uint32(machhead->flags) & ~MH_PIE);
+#endif
 }
 
 #if defined(MH_MAGIC_64)

--- a/SheepShaver/src/Unix/Makefile.in
+++ b/SheepShaver/src/Unix/Makefile.in
@@ -188,6 +188,8 @@ $(OBJ_DIR)/%.o : ../slirp/%.c
 	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) $(SLIRP_CFLAGS) -c $< -o $@
 $(OBJ_DIR)/%.o : %.c
 	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) -c $< -o $@
+$(OBJ_DIR)/DiskType.o : DiskType.m
+	$(CC) $(CPPFLAGS) $(DEFS) $(CFLAGS) -c $< -o $@
 $(OBJ_DIR)/%.o : %.cpp
 	$(CXX) $(CPPFLAGS) $(DEFS) $(CXXFLAGS) -c $< -o $@
 $(OBJ_DIR)/%.o : %.mm

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -936,6 +936,18 @@ AC_TRANSLATE_DEFINE(HAVE_MMAP_VM, $have_mmap_vm,
 
 fi dnl HAVE_MMAP_VM
 
+dnl Check if we can disable position-independent code
+AC_CACHE_CHECK([how to disable position-independent code],
+  ac_cv_no_pie, [
+  ac_cv_no_pie='-Wl,-no_pie'
+  saved_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $ac_cv_no_pie"
+  AC_TRY_LINK(,,,[ac_cv_no_pie="cannot"])
+  if [[ "$ac_cv_no_pie" = "cannot" ]]; then
+    LDFLAGS="$saved_LDFLAGS"
+  fi
+])
+
 dnl Check if we can modify the __PAGEZERO segment for use as Low Memory
 AC_CACHE_CHECK([whether __PAGEZERO can be Low Memory area 0x0000-0x3000],
   ac_cv_pagezero_hack, [

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -625,7 +625,7 @@ darwin*)
   if [[ "x$ac_cv_framework_Carbon" = "xyes" ]]; then
     EXTFSSRC=../MacOSX/extfs_macosx.cpp
     if [[ "x$ac_cv_framework_AppKit" = "xyes" -a "x$WANT_GTK" = "xno" ]]; then
-      PREFSSRC="../MacOSX/prefs_macosx.mm ../MacOSX/Launcher/VMSettingsController.mm"
+      PREFSSRC="../MacOSX/prefs_macosx.mm ../MacOSX/Launcher/VMSettingsController.mm ../MacOSX/Launcher/DiskType.m"
       CPPFLAGS="$CPPFLAGS -I../MacOSX/Launcher"
     fi
   fi


### PR DESCRIPTION
Fix building on Mac OS X 10.10/10.11:

* Fixes a missing dependency. Maybe this is needed on other OS X versions too?
* Builds without ASLR, which is necessary for real addressing.

Note that this doesn't fix the problems with dyngen and clang—if you want to build on recent OS X, you'll need to copy over *-dyngen-ops.o from an earlier OS X build.