### PR TITLE
Making tunconfig working

### DIFF
--- a/BasiliskII/src/Unix/tunconfig
+++ b/BasiliskII/src/Unix/tunconfig
@@ -77,7 +77,7 @@ $IPTABLES -L -n -t nat > /dev/null || exit 1
 #########################################################
 
 {
-    $IPTABLES -t nat -D POSTROUTING -s $TUN_NET -d ! $TUN_NET -j MASQUERADE
+    $IPTABLES -t nat -D POSTROUTING -s $TUN_NET ! -d $TUN_NET -j MASQUERADE
 } >& /dev/null
 
 #########################################################
@@ -96,7 +96,7 @@ $IPTABLES -L -n -t nat > /dev/null || exit 1
     $IFCONFIG $TUN_DEV $TUN_HOST
 
     # masquerade the tun network
-    $IPTABLES -t nat -A POSTROUTING -s $TUN_NET -d ! $TUN_NET -j MASQUERADE
+    $IPTABLES -t nat -A POSTROUTING -s $TUN_NET ! -d $TUN_NET -j MASQUERADE
 }
 
 exit 0


### PR DESCRIPTION
Tunconfig was not working for me until I changed this.

Also the tun/tap networking, described here - http://www.emaculation.com/forum/viewtopic.php?f=20&t=2504 - was the only one that worked for me on Ubuntu.

The sheep_net driver did not even build; I made changes according to this, otherwise unrelated, thread - https://communities.vmware.com/thread/516196 - and it built, but it didn't work anyway.

The tun/tap solution as described in the forum worked.... after I fixed the script.
