### PR TITLE
Fix sk_alloc function change since 4.2 Linux kernel.

### DIFF
--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -610,6 +610,9 @@ static int sheep_net_ioctl(struct inode *inode, struct file *f, unsigned int cod
 			v->pt.type = htons(ETH_P_ALL);
 			v->pt.dev = v->ether;
 			v->pt.func = sheep_net_receiver;
+#ifdef LINUX_26
+			v->pt.af_packet_priv = v;
+#endif
 			dev_add_pack(&v->pt);
 #ifndef LINUX_24
 			dev_unlock_list();
@@ -715,7 +718,11 @@ static int sheep_net_receiver(struct sk_buff *skb, struct net_device *dev, struc
 static int sheep_net_receiver(struct sk_buff *skb, struct net_device *dev, struct packet_type *pt)
 #endif
 {
+#ifdef LINUX_26
+	struct SheepVars *v = (struct SheepVars *)pt->af_packet_priv;
+#else
 	struct SheepVars *v = (struct SheepVars *)pt;
+#endif
 	struct sk_buff *skb2;
 	int fake;
 	int multicast;

--- a/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
+++ b/BasiliskII/src/Unix/Linux/NetDriver/sheep_net.c
@@ -23,6 +23,15 @@
 #include <linux/version.h>
 #include <linux/init.h>
 
+/* wrap up socket object allocation */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 00)
+	#define compat_sk_alloc(_net, _family, _priority, _proto) \
+		sk_alloc(_net, _family, _priority, _proto, 0)
+#else
+	#define compat_sk_alloc(_net, _family, _priority, _proto) \
+		sk_alloc(_net, _family, _priority, _proto)
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
 #define LINUX_3_15
 #endif
@@ -587,7 +596,7 @@ static int sheep_net_ioctl(struct inode *inode, struct file *f, unsigned int cod
 
 			/* Allocate socket */
 #ifdef LINUX_26
-			v->skt = sk_alloc(dev_net(v->ether), GFP_USER, 1, &sheep_proto);
+			v->skt = compat_sk_alloc(dev_net(v->ether), GFP_USER, 1, &sheep_proto);
 #else
 			v->skt = sk_alloc(0, GFP_USER, 1);
 #endif


### PR DESCRIPTION
Since 4.2, sk_alloc added flag to indicate if it is kernel socket or not. This patch make sheep_net module compatible with kernel after 4.2.