### PR TITLE
Customized color depth in SDL

### DIFF
--- a/BasiliskII/src/SDL/video_sdl.cpp
+++ b/BasiliskII/src/SDL/video_sdl.cpp
@@ -216,6 +216,27 @@ static inline void vm_release_framebuffer(void *fb, uint32 size)
 	vm_release(fb, size);
 }
 
+static inline int get_customized_color_depth(int default_depth)
+{
+	int display_color_depth = PrefsFindInt32("displaycolordepth");
+
+	D(bug("Get displaycolordepth %d\n", display_color_depth));
+
+	if(0 == display_color_depth)
+		return default_depth;
+	else{
+		switch (display_color_depth) {
+		case 8:
+			return VIDEO_DEPTH_8BIT;
+		case 15: case 16:
+			return VIDEO_DEPTH_16BIT;
+		case 24: case 32:
+			return VIDEO_DEPTH_32BIT;
+		default:
+			return default_depth;
+		}
+	}
+}
 
 /*
  *  Windows message handler
@@ -1144,8 +1165,12 @@ bool VideoInit(bool classic)
 	}
 #endif
 
+	int color_depth = get_customized_color_depth(default_depth);
+
+	D(bug("Return get_customized_color_depth %d\n", color_depth));
+
 	// Create SDL_monitor_desc for this (the only) display
-	SDL_monitor_desc *monitor = new SDL_monitor_desc(VideoModes, (video_depth)default_depth, default_id);
+	SDL_monitor_desc *monitor = new SDL_monitor_desc(VideoModes, (video_depth)color_depth, default_id);
 	VideoMonitors.push_back(monitor);
 
 	// Open display

--- a/BasiliskII/src/prefs_items.cpp
+++ b/BasiliskII/src/prefs_items.cpp
@@ -28,6 +28,7 @@
 // Except for "disk", "floppy", "cdrom", "scsiX", "screen", "rom" and "ether",
 // these are guaranteed to be in the prefs.
 prefs_desc common_prefs_items[] = {
+	{"displaycolordepth", TYPE_INT32, false, "display color depth"},
 	{"disk", TYPE_STRING, true,       "device/file name of Mac volume"},
 	{"floppy", TYPE_STRING, true,     "device/file name of Mac floppy drive"},
 	{"cdrom", TYPE_STRING, true,      "device/file names of Mac CD-ROM drive"},
@@ -86,6 +87,7 @@ void AddPrefsDefaults(void)
 	PrefsAddInt32("frameskip", 6);
 	PrefsAddInt32("modelid", 5);	// Mac IIci
 	PrefsAddInt32("cpu", 3);		// 68030
+	PrefsAddInt32("displaycolordepth", 0);
 	PrefsAddBool("fpu", false);
 	PrefsAddBool("nocdrom", false);
 	PrefsAddBool("nosound", false);


### PR DESCRIPTION
Add customized color depth in SDL. To change color depth, add bit of color depth as displaycolordepth prefs in .basilisk_ii_prefs.

I tested it in Linux and Mac. It works. Finally, I can play Lemmings in color.