### PR TITLE
Add MacTimeToTime to SheepShaver's macos_util.

### DIFF
--- a/SheepShaver/src/include/macos_util.h
+++ b/SheepShaver/src/include/macos_util.h
@@ -357,6 +357,7 @@ extern uint32 FindLibSymbol(const char *lib, const char *sym);	// Find symbol in
 extern void InitCallUniversalProc(void);				// Init CallUniversalProc()
 extern long CallUniversalProc(void *upp, uint32 info);	// CallUniversalProc()
 extern uint32 TimeToMacTime(time_t t);					// Convert time_t value to MacOS time
+extern time_t MacTimeToTime(uint32 t);				// Convert MacOS time to time_t value
 extern uint32 Mac_sysalloc(uint32 size);				// Allocate block in MacOS system heap zone
 extern void Mac_sysfree(uint32 addr);					// Release block occupied by the nonrelocatable block p
 

--- a/SheepShaver/src/macos_util.cpp
+++ b/SheepShaver/src/macos_util.cpp
@@ -340,6 +340,17 @@ uint32 TimeToMacTime(time_t t)
 
 
 /*
+ *  Convert MacOS time to time_t (seconds since 1.1.1970)
+ */
+
+time_t MacTimeToTime(uint32 t)
+{
+	// simply subtract number of seconds between 1.1.1904 and 1.1.1970
+	return t - 2082826800;
+}
+
+
+/*
  *  Memory allocators in MacOS system heap zone
  */
 


### PR DESCRIPTION
Commit e1693eb92bcf13101f55da460b315fd48028c4ed made extfs_unix.cpp
require this function in both BasiliskII and SheepShaver, but only added
the function itself to BasiliskII.