### PR TITLE
Prefer Mach time functions over clock_gettime()

### DIFF
--- a/BasiliskII/src/Unix/timer_unix.cpp
+++ b/BasiliskII/src/Unix/timer_unix.cpp
@@ -57,13 +57,13 @@ static inline void mach_current_time(tm_time_t &t) {
 void Microseconds(uint32 &hi, uint32 &lo)
 {
 	D(bug("Microseconds\n"));
-#if defined(HAVE_CLOCK_GETTIME)
-	struct timespec t;
-	clock_gettime(CLOCK_REALTIME, &t);
-	uint64 tl = (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
-#elif defined(__MACH__)
+#if defined(PRECISE_TIMING_MACH)
 	tm_time_t t;
 	mach_current_time(t);
+	uint64 tl = (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
+#elif defined(HAVE_CLOCK_GETTIME)
+	struct timespec t;
+	clock_gettime(CLOCK_REALTIME, &t);
 	uint64 tl = (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
 #else
 	struct timeval t;
@@ -91,10 +91,10 @@ uint32 TimerDateTime(void)
 
 void timer_current_time(tm_time_t &t)
 {
-#ifdef HAVE_CLOCK_GETTIME
-	clock_gettime(CLOCK_REALTIME, &t);
-#elif defined(__MACH__)
+#if defined(PRECISE_TIMING_MACH)
 	mach_current_time(t);
+#elif defined(HAVE_CLOCK_GETTIME)
+	clock_gettime(CLOCK_REALTIME, &t);
 #else
 	gettimeofday(&t, NULL);
 #endif
@@ -229,13 +229,13 @@ int32 timer_host2mac_time(tm_time_t hosttime)
 
 uint64 GetTicks_usec(void)
 {
-#ifdef HAVE_CLOCK_GETTIME
-	struct timespec t;
-	clock_gettime(CLOCK_REALTIME, &t);
-	return (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
-#elif defined(__MACH__)
+#if defined(PRECISE_TIMING_MACH)
 	tm_time_t t;
 	mach_current_time(t);
+	return (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
+#elif defined(HAVE_CLOCK_GETTIME)
+	struct timespec t;
+	clock_gettime(CLOCK_REALTIME, &t);
 	return (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
 #else
 	struct timeval t;

--- a/SheepShaver/src/Unix/sysdeps.h
+++ b/SheepShaver/src/Unix/sysdeps.h
@@ -401,11 +401,20 @@ static inline int spin_trylock(spinlock_t *lock)
 }
 #endif
 
+// High-precision timing
+#if defined(HAVE_PTHREADS) && defined(HAVE_CLOCK_NANOSLEEP)
+#define PRECISE_TIMING 1
+#define PRECISE_TIMING_POSIX 1
+#elif defined(HAVE_PTHREADS) && defined(__MACH__)
+#define PRECISE_TIMING 1
+#define PRECISE_TIMING_MACH 1
+#endif
+
 // Time data type for Time Manager emulation
-#ifdef HAVE_CLOCK_GETTIME
-typedef struct timespec tm_time_t;
-#elif defined(__MACH__)
+#if defined(PRECISE_TIMING_MACH)
 typedef mach_timespec_t tm_time_t;
+#elif defined(HAVE_CLOCK_GETTIME)
+typedef struct timespec tm_time_t;
 #else
 typedef struct timeval tm_time_t;
 #endif
@@ -417,15 +426,6 @@ typedef struct timeval tm_time_t;
 #define VAX_FLOAT_FORMAT 2
 #define IBM_FLOAT_FORMAT 3
 #define C4X_FLOAT_FORMAT 4
-
-// High-precision timing
-#if defined(HAVE_PTHREADS) && defined(HAVE_CLOCK_NANOSLEEP)
-#define PRECISE_TIMING 1
-#define PRECISE_TIMING_POSIX 1
-#elif defined(HAVE_PTHREADS) && defined(__MACH__)
-#define PRECISE_TIMING 1
-#define PRECISE_TIMING_MACH 1
-#endif
 
 // Timing functions
 extern uint64 GetTicks_usec(void);


### PR DESCRIPTION
On macOS 10.12, clock_gettime() exists, but clock_nanosleep() does not, so it
must use PRECISE_TIMING_MACH.