### PR TITLE
Fix Mac OS X Sierra introduce clock_gettime

### DIFF
--- a/BasiliskII/src/Unix/sysdeps.h
+++ b/BasiliskII/src/Unix/sysdeps.h
@@ -185,10 +185,10 @@ typedef char * caddr_t;
 #endif
 
 /* Time data type for Time Manager emulation */
-#ifdef HAVE_CLOCK_GETTIME
-typedef struct timespec tm_time_t;
-#elif defined(__MACH__)
+#if defined(__MACH__)
 typedef mach_timespec_t tm_time_t;
+#elif defined(HAVE_CLOCK_GETTIME)
+typedef struct timespec tm_time_t;
 #else
 typedef struct timeval tm_time_t;
 #endif
@@ -266,7 +266,7 @@ static inline int testandset(volatile int *p)
 	__asm__ __volatile__("0: cs    %0,%1,0(%2)\n"
 						 "   jl    0b"
 						 : "=&d" (ret)
-						 : "r" (1), "a" (p), "0" (*p) 
+						 : "r" (1), "a" (p), "0" (*p)
 						 : "cc", "memory" );
 	return ret;
 }
@@ -315,7 +315,7 @@ static inline int testandset(volatile int *p)
 	__asm__ __volatile__("swp %0, %1, [%2]"
 						 : "=r"(ret)
 						 : "0"(1), "r"(p));
-	
+
 	return ret;
 }
 #endif

--- a/BasiliskII/src/Unix/timer_unix.cpp
+++ b/BasiliskII/src/Unix/timer_unix.cpp
@@ -44,7 +44,7 @@ static inline void mach_current_time(tm_time_t &t) {
 		host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &host_clock);
 		host_clock_inited = true;
 	}
-	
+
 	clock_get_time(host_clock, &t);
 }
 #endif
@@ -57,13 +57,13 @@ static inline void mach_current_time(tm_time_t &t) {
 void Microseconds(uint32 &hi, uint32 &lo)
 {
 	D(bug("Microseconds\n"));
-#if defined(HAVE_CLOCK_GETTIME)
-	struct timespec t;
-	clock_gettime(CLOCK_REALTIME, &t);
-	uint64 tl = (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
-#elif defined(__MACH__)
+#if defined(__MACH__)
 	tm_time_t t;
 	mach_current_time(t);
+	uint64 tl = (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
+#elif defined(HAVE_CLOCK_GETTIME)
+	struct timespec t;
+	clock_gettime(CLOCK_REALTIME, &t);
 	uint64 tl = (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
 #else
 	struct timeval t;
@@ -91,10 +91,10 @@ uint32 TimerDateTime(void)
 
 void timer_current_time(tm_time_t &t)
 {
-#ifdef HAVE_CLOCK_GETTIME
-	clock_gettime(CLOCK_REALTIME, &t);
-#elif defined(__MACH__)
+#if defined(__MACH__)
 	mach_current_time(t);
+#elif defined(HAVE_CLOCK_GETTIME)
+	clock_gettime(CLOCK_REALTIME, &t);
 #else
 	gettimeofday(&t, NULL);
 #endif
@@ -229,13 +229,13 @@ int32 timer_host2mac_time(tm_time_t hosttime)
 
 uint64 GetTicks_usec(void)
 {
-#ifdef HAVE_CLOCK_GETTIME
-	struct timespec t;
-	clock_gettime(CLOCK_REALTIME, &t);
-	return (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
-#elif defined(__MACH__)
+#if defined(__MACH__)
 	tm_time_t t;
 	mach_current_time(t);
+	return (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
+#elif defined(HAVE_CLOCK_GETTIME)
+	struct timespec t;
+	clock_gettime(CLOCK_REALTIME, &t);
 	return (uint64)t.tv_sec * 1000000 + t.tv_nsec / 1000;
 #else
 	struct timeval t;


### PR DESCRIPTION
Mac OS X Sierra introduce clock_gettime. This breaks HAVE_CLOCK_TIME macro and corresponding get time logic. Because now Sierra has its clock_gettime function while the earlier Mac don't.

The simple fix that won't break Mac OS X earlier than Sierra is to move HAVE_CLCOK_GETTIME down and let Mac OS X condition check up. In this case, the old way is always used regardless of the existence of clock_gettime in different Mac OS X.

I tested it on Sierra and Linux. It works. In theory, it should also work for earlier Mac OS X.