### PR TITLE
Use ucontext_t instead of struct ucontext

### DIFF
--- a/BasiliskII/src/CrossPlatform/sigsegv.cpp
+++ b/BasiliskII/src/CrossPlatform/sigsegv.cpp
@@ -342,12 +342,12 @@ static void powerpc_decode_instruction(instruction_t *instruction, unsigned int 
 #define SIGSEGV_REGISTER_FILE			(unsigned long *)&SIGSEGV_CONTEXT_REGS->nip, (unsigned long *)(SIGSEGV_CONTEXT_REGS->gpr)
 #define SIGSEGV_SKIP_INSTRUCTION		powerpc_skip_instruction
 #elif (defined(arm) || defined(__arm__))
-#define SIGSEGV_CONTEXT_REGS			(((struct ucontext *)scp)->uc_mcontext)
+#define SIGSEGV_CONTEXT_REGS			(((ucontext_t *)scp)->uc_mcontext)
 #define SIGSEGV_FAULT_INSTRUCTION		(SIGSEGV_CONTEXT_REGS.arm_pc)
 #define SIGSEGV_REGISTER_FILE			(&SIGSEGV_CONTEXT_REGS.arm_r0)
 #define SIGSEGV_SKIP_INSTRUCTION		arm_skip_instruction
 #elif (defined(mips) || defined(__mips__))
-#define SIGSEGV_CONTEXT_REGS			(((struct ucontext *)scp)->uc_mcontext)
+#define SIGSEGV_CONTEXT_REGS			(((ucontext_t *)scp)->uc_mcontext)
 #define SIGSEGV_FAULT_INSTRUCTION		(SIGSEGV_CONTEXT_REGS.pc)
 #define SIGSEGV_REGISTER_FILE			&SIGSEGV_CONTEXT_REGS.pc, &SIGSEGV_CONTEXT_REGS.gregs[0]
 #define SIGSEGV_SKIP_INSTRUCTION		mips_skip_instruction


### PR DESCRIPTION
ucontext_t is what POSIX requires; glibc no longer provides struct
ucontext as of 2.26: https://sourceware.org/glibc/wiki/Release/2.26

(Most architectures were already using ucontext_t, so this also makes
things more consistent; only arm and mips change.)