### PR TITLE
Enhance ROM break point feature.

### DIFF
--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <errno.h>
+#include <sstream>
 
 #ifdef USE_SDL
 # include <SDL.h>
@@ -371,7 +372,8 @@ static void usage(const char *prg_name)
 		"\nUnix options:\n"
 		"  --config FILE\n    read/write configuration from/to FILE\n"
 		"  --display STRING\n    X display to use\n"
-		"  --break ADDRESS\n    set ROM breakpoint\n"
+		"  --break ADDRESS\n    set ROM breakpoint in hexadecimal\n"
+		"  --loadbreak FILE\n    load breakpoint from FILE\n"
 		"  --rominfo\n    dump ROM information\n", prg_name
 	);
 	LoadPrefs(NULL); // read the prefs file so PrefsPrintUsage() will print the correct default values
@@ -413,9 +415,17 @@ int main(int argc, char **argv)
 		} else if (strcmp(argv[i], "--break") == 0) {
 			argv[i++] = NULL;
 			if (i < argc) {
-				ROMBreakpoint = strtol(argv[i], NULL, 0);
+				std::stringstream ss;
+				ss << std::hex << argv[i];
+				ss >>	ROMBreakpoint;
 				argv[i] = NULL;
 			}
+#ifdef ENABLE_MON
+		} else if (strcmp(argv[i], "--loadbreak") == 0) {
+			argv[i++] = NULL;
+			if (i < argc)
+				mon_load_break_point(argv[i]);
+#endif
 		} else if (strcmp(argv[i], "--config") == 0) {
 			argv[i++] = NULL;
 			if (i < argc) {

--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -417,7 +417,7 @@ int main(int argc, char **argv)
 			if (i < argc) {
 				std::stringstream ss;
 				ss << std::hex << argv[i];
-				ss >>	ROMBreakpoint;
+				ss >> ROMBreakpoint;
 				argv[i] = NULL;
 			}
 #ifdef ENABLE_MON

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -32,6 +32,11 @@
 #include "video.h"
 #include "extfs.h"
 #include "prefs.h"
+
+#if ENABLE_MON
+#include "mon.h"
+#endif
+
 #include "rom_patches.h"
 
 #define DEBUG 0
@@ -1678,8 +1683,14 @@ bool PatchROM(void)
 
 	// Install breakpoint
 	if (ROMBreakpoint) {
+#if ENABLE_MON
+		mon_add_break_point(ROMBaseMac + ROMBreakpoint);
+		printf("ROM start address at %08lx\n", ROMBaseMac);
+		printf("Set ROM break point at %08lx\n", ROMBaseMac + ROMBreakpoint);
+#else
 		uint16 *wp = (uint16 *)(ROMBaseHost + ROMBreakpoint);
 		*wp = htons(M68K_EMUL_BREAK);
+#endif
 	}
 
 	// Clear caches as we loaded and patched code

--- a/cxmon/src/mon.cpp
+++ b/cxmon/src/mon.cpp
@@ -154,7 +154,7 @@ void mon_add_command(const char *name, void (*func)(), const char *help_text)
 
 void mon_error(const char *s)
 {
-	fprintf(monerr == NULL? stdout: monerr, "*** %s\n", s);
+	fprintf(monerr == NULL? stdout : monerr, "*** %s\n", s);
 }
 
 
@@ -1034,15 +1034,15 @@ void mon_change_dir()
  * Add break point
  */
 
-void mon_add_break_point(uintptr adr)
+void mon_add_break_point(uintptr addr)
 {
-	BREAK_POINT_SET::iterator it;
+	BREAK_POINT_SET::iterator it = disabled_break_points.find(addr);
 	// Save break point
-	if ((it = disabled_break_points.find(adr)) == disabled_break_points.end())
-		active_break_points.insert(adr);
-	else {
+	if (it == disabled_break_points.end()) {
+		active_break_points.insert(addr);
+	} else {
 		disabled_break_points.erase(it);
-		active_break_points.insert(adr);
+		active_break_points.insert(addr);
 	}
 }
 
@@ -1050,7 +1050,7 @@ void mon_add_break_point(uintptr adr)
 /*
  * Load break point from file
  */
-void mon_load_break_point(char* file_path)
+void mon_load_break_point(const char* file_path)
 {
 	FILE *file;
 	if (!(file = fopen(file_path, "r"))) {

--- a/cxmon/src/mon.h
+++ b/cxmon/src/mon.h
@@ -33,6 +33,9 @@ void mon_init();
 void mon_exit();
 void mon(int argc, char **argv);
 
+// Break points prompt
+const char STR_ACTIVE_BREAK_POINTS[]	= "Active Break Points:\n";
+const char STR_DISABLED_BREAK_POINTS[]	= "Disabled Break Points:\n";
 
 /*
  *  Definitions for adding commands to mon
@@ -104,5 +107,8 @@ extern void mon_write_word(uintptr adr, uint32 l);
 
 // Check if break point is set
 #define IS_BREAK_POINT(address) (active_break_points.find(address) != active_break_points.end())
+// Add break point
+extern void mon_add_break_point(uintptr adr);
+extern void mon_load_break_point(char* file_path);
 
 #endif

--- a/cxmon/src/mon.h
+++ b/cxmon/src/mon.h
@@ -108,7 +108,7 @@ extern void mon_write_word(uintptr adr, uint32 l);
 // Check if break point is set
 #define IS_BREAK_POINT(address) (active_break_points.find(address) != active_break_points.end())
 // Add break point
-extern void mon_add_break_point(uintptr adr);
-extern void mon_load_break_point(char* file_path);
+extern void mon_add_break_point(uintptr addr);
+extern void mon_load_break_point(const char* file_path);
 
 #endif

--- a/cxmon/src/mon_cmd.cpp
+++ b/cxmon/src/mon_cmd.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  mon_cmd.cpp - cxmon standard commands
  *
  *  cxmon (C) 1997-2004 Christian Bauer, Marc Hellwig
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <assert.h>
-#include <sstream>
 
 #include "mon.h"
 #include "mon_cmd.h"
@@ -32,9 +31,6 @@
 #define VERSION "3"
 #endif
 
-
-static const char STR_ACTIVE_BREAK_POINTS[]		= "Active Break Points:\n";
-static const char STR_DISABLED_BREAK_POINTS[]	= "Disabled Break Points:\n";
 
 /*
  *  range_args = [expression] [[COMMA] expression] END
@@ -323,14 +319,7 @@ void break_point_add(void)
 		return;
 	}
 
-	BREAK_POINT_SET::iterator it;
-	// Save break point
-	if ((it = disabled_break_points.find(address)) == disabled_break_points.end())
-		active_break_points.insert(address);
-	else {
-		disabled_break_points.erase(it);
-		active_break_points.insert(address);
-	}
+	mon_add_break_point(address);
 }
 
 
@@ -521,38 +510,8 @@ void break_point_load(void)
 		return;
 	}
 
-	FILE *file;
-	if (!(file = fopen(mon_string, "r"))) {
-		mon_error("Unable to create file");
-		return;
-	}
-
-	char line_buff[1024];
-	bool is_disabled_break_points = false;
-
-	if (fgets(line_buff, sizeof(line_buff), file) == NULL ||
-			strcmp(line_buff, STR_ACTIVE_BREAK_POINTS) != 0) {
-		mon_error("Invalid break point file format!");
-		fclose(file);
-		return;
-	}
-
-	while (fgets(line_buff, sizeof(line_buff), file) != NULL) {
-		if (strcmp(line_buff, STR_DISABLED_BREAK_POINTS) == 0) {
-			is_disabled_break_points = true;
-			continue;
-		}
-		uintptr address;
-		std::stringstream ss;
-		ss << std::hex << line_buff;
-		ss >> address;
-		if (is_disabled_break_points)
-			disabled_break_points.insert(address);
-		else
-			active_break_points.insert(address);
-	}
-
-	fclose(file);
+	// load from file
+	mon_load_break_point(mon_string);
 }
 
 


### PR DESCRIPTION
1. Change '--break' input option format. Too much typing by taking address in decimal format. Change to hexadecimal input.
1. Allow ROM break point to continue to execution. The original ROM break point just replaced instruction in ROM break point address with emul_op M68K_EMUL_BREAK. This halts emulation right at the break point. The patch is less invasive than the original approach. It allows emulation to continue to run by pressing 'x' to exit from cxmon.
1. Add option '--loadbreak' which load break point from file before emulation start.

I'm using this feature to poke around ROM especially 24bit ROM which BII doesn't support well.