### PR TITLE
Patch installing BII emulated hard drive in .sound driver Open call.

### DIFF
--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -884,12 +884,10 @@ static bool patch_rom_classic(void)
 	*wp++ = htons(M68K_NOP);
 	*wp = htons(M68K_NOP);
 
-	// Install our own drivers
-	wp = (uint16 *)(ROMBaseHost + 0x3f82a);
+	// Don't open .Sound driver but install our own drivers
+	wp = (uint16 *)(ROMBaseHost + 0x36caa);
 	*wp++ = htons(M68K_EMUL_OP_INSTALL_DRIVERS);
-	*wp++ = htons(M68K_NOP);
-	*wp++ = htons(M68K_NOP);
-	*wp = htons(M68K_NOP);
+	*wp = htons(0x4e75); //rts
 
 #if 1
 	// Don't look for SCSI devices


### PR DESCRIPTION
I tested this patch in Mac SE and Mac Classic ROM under System 6. It make emulated hard drive works.