### PR TITLE
fix for extfs on 64-bit macOS/iOS

### DIFF
--- a/BasiliskII/src/extfs.cpp
+++ b/BasiliskII/src/extfs.cpp
@@ -176,7 +176,7 @@ static uint32 next_cnid = fsUsrCNID;	// Next available CNID
 #if defined __APPLE__ && defined __MACH__
 struct crtimebuf {
     u_int32_t length;
-	struct timespec crtime;
+    struct timespec crtime;
 } __attribute__((aligned(4), packed));
 
 static uint32 do_get_creation_time(const char *path)

--- a/BasiliskII/src/extfs.cpp
+++ b/BasiliskII/src/extfs.cpp
@@ -175,9 +175,9 @@ static uint32 next_cnid = fsUsrCNID;	// Next available CNID
 
 #if defined __APPLE__ && defined __MACH__
 struct crtimebuf {
-	unsigned long length;
+    u_int32_t length;
 	struct timespec crtime;
-};
+} __attribute__((aligned(4), packed));
 
 static uint32 do_get_creation_time(const char *path)
 {


### PR DESCRIPTION
`crtimebuf` doesn't have the correct type or alignment for 64-bit platforms (see examples from the [`getattrlist` man page](https://www.unix.com/man-page/osx/2/getattrlist/)).
This causes the `timespec` structure to be read incorrectly, and crashes when accessing extfs because `localtime` returns `NULL` in `TimeToMacTime`.

