### PR TITLE
Fix TUN/TAP detection on CentOS 7 (#include <sys/socket.h>) (fixes #153).

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -906,6 +906,9 @@ dnl Check that the host supports TUN/TAP devices
 AC_CACHE_CHECK([whether TUN/TAP is supported],
   ac_cv_tun_tap_support, [
   AC_TRY_COMPILE([
+    #ifdef HAVE_SYS_SOCKET_H
+    #include <sys/socket.h>
+    #endif
     #if defined(HAVE_LINUX_IF_H) && defined(HAVE_LINUX_IF_TUN_H)
     #include <linux/if.h>
     #include <linux/if_tun.h>


### PR DESCRIPTION
Previously, "checking whether TUN/TAP is supported..." in "configure"
failed to detect TUN/TAP support due to compile errors due to "struct
sockaddr" not being defined.  This fix causes sys/socket.h to be
#included if it exists.

As noted in https://github.com/cebix/macemu/issues/153#issuecomment-354260998: "Pull Request #64 includes a fix for this issue in BasiliskII/src/Unix/configure.ac amongst other changes."  However, that PR doesn't include the #ifdef that I've included here.  I'm assuming it's preferable to use the #ifdef; it certainly works for me anyway.