### PR TITLE
Fix link error due to missing X11 libraries (fixes #152).

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -324,7 +324,7 @@ else
 fi
 
 dnl We need X11, if not using SDL or Mac GUI.
-if [[ "x$WANT_SDL_VIDEO" = "xno" -a "x$WANT_MACOSX_GUI" = "xno"]]; then
+if [[ "x$WANT_SDL_VIDEO" = "xno" -a "x$WANT_MACOSX_GUI" = "xno" ]]; then
   AC_PATH_XTRA
   if [[ "x$no_x" = "xyes" ]]; then
     AC_MSG_ERROR([You need X11 to run Basilisk II.])


### PR DESCRIPTION
c18d6fa removed a space from BasiliskII/src/Unix/configure.ac, which
caused "configure" to fail to properly determine the correct set of
libraries to link against when using X11, which caused linking to
fail.  This fix restores the missing space.