### PR TITLE
Avoid an all-zero Ethernet/MAC address when using TUN/TAP (fixes #154).

### DIFF
--- a/BasiliskII/src/Unix/ether_unix.cpp
+++ b/BasiliskII/src/Unix/ether_unix.cpp
@@ -371,7 +371,7 @@ bool ether_init(void)
 #endif
 
 	// Get Ethernet address
-	if (net_if_type == NET_IF_ETHERTAP) {
+	if (net_if_type == NET_IF_ETHERTAP || net_if_type == NET_IF_TUNTAP) {
 		pid_t p = getpid();	// If configured for multicast, ethertap requires that the lower 32 bit of the Ethernet address are our PID
 		ether_addr[0] = 0xfe;
 		ether_addr[1] = 0xfd;


### PR DESCRIPTION
Previously, when "ether tun" configuration was used on a Linux host,
packets were sent with Ethernet/MAC address 00:00:00:00:00:00.  Under
CentOS 7 at least, this did not appear to cause any issues where the
tun interface on the host was configured with an IP address, but when
an attempt was made to bridge the tun interface, it was no longer
possible to establish IP communication between the emulated machine
and either the Linux host or a Windows NT Server 4 VM.

This fix causes an Ethernet/MAC address to be generated in the same
way when using TUN/TAP as is done for ethertap.