### PR TITLE
Mac GUI: don't show /dev/poll/cdrom if it is configured as cdrom 

### DIFF
--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -51,6 +51,8 @@ void prefs_exit()
 }
 #endif
 
+#define DEFAULT_CDROM_PATH "/dev/poll/cdrom"
+
 @implementation VMSettingsController
 
 + (id) sharedInstance
@@ -121,7 +123,7 @@ static NSString *getStringFromPrefs(const char *key)
   index = 0;
   while ((dsk = PrefsFindString("cdrom", index++)) != NULL) {
     NSString *path = [NSString stringWithUTF8String: dsk ];
-      if (![path isEqualToString:@"/dev/poll/cdrom"]) {
+      if (![path isEqualToString:@DEFAULT_CDROM_PATH]) {
         DiskType *disk = [[[DiskType alloc] init] autorelease];
         [disk setPath:[NSString stringWithUTF8String: dsk ]];
         [disk setIsCDROM:YES];
@@ -416,6 +418,8 @@ static NSString *makeRelativeIfNecessary(NSString *path)
     DiskType *d = [diskArray objectAtIndex:i];
     PrefsAddString([d isCDROM] ? "cdrom" : "disk", [[d path] UTF8String]);
   }
+
+  PrefsAddString("cdrom", DEFAULT_CDROM_PATH);
 
   PrefsReplaceInt32("bootdriver", ([bootFrom indexOfSelectedItem] == 1 ? CDROMRefNum : 0));
   PrefsReplaceString("rom", [[romFile stringValue] UTF8String]);

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -410,7 +410,7 @@ static NSString *makeRelativeIfNecessary(NSString *path)
   const char *path;
   int index = 0;
   while ((path = PrefsFindString("cdrom", index)) != NULL) {
-	NSString *p = [NSString stringWithUTF8String: path];
+    NSString *p = [NSString stringWithUTF8String: path];
     if (![p hasPrefix:@"/dev/"]) {
       PrefsRemoveItem("cdrom", index);
     } else {

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -413,9 +413,12 @@ static NSString *makeRelativeIfNecessary(NSString *path)
 	NSString *p = [NSString stringWithUTF8String: path];
     if(![p hasPrefix:@"/dev/"]) {
       PrefsRemoveItem("cdrom", index);
+    }
+	else {
+		// only increase the index if the current entry has not been deleted
+		// if it has been deleted, the next entry is on the current entrys index
+		index++;
 	}
-	  
-	index++;
   }
 
   // Write all disks

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -414,11 +414,11 @@ static NSString *makeRelativeIfNecessary(NSString *path)
     if(![p hasPrefix:@"/dev/"]) {
       PrefsRemoveItem("cdrom", index);
     }
-	else {
-		// only increase the index if the current entry has not been deleted
-		// if it has been deleted, the next entry is on the current entrys index
-		index++;
-	}
+    else {
+      // only increase the index if the current entry has not been deleted
+      // if it has been deleted, the next entry is on the current entrys index
+      index++;
+    }
   }
 
   // Write all disks

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -51,8 +51,6 @@ void prefs_exit()
 }
 #endif
 
-#define DEFAULT_CDROM_PATH "/dev/poll/cdrom"
-
 @implementation VMSettingsController
 
 + (id) sharedInstance
@@ -123,7 +121,7 @@ static NSString *getStringFromPrefs(const char *key)
   index = 0;
   while ((dsk = PrefsFindString("cdrom", index++)) != NULL) {
     NSString *path = [NSString stringWithUTF8String: dsk ];
-      if (![path isEqualToString:@DEFAULT_CDROM_PATH]) {
+	  if (![path hasPrefix:@"/dev/"]) {
         DiskType *disk = [[[DiskType alloc] init] autorelease];
         [disk setPath:[NSString stringWithUTF8String: dsk ]];
         [disk setIsCDROM:YES];
@@ -418,8 +416,6 @@ static NSString *makeRelativeIfNecessary(NSString *path)
     DiskType *d = [diskArray objectAtIndex:i];
     PrefsAddString([d isCDROM] ? "cdrom" : "disk", [[d path] UTF8String]);
   }
-
-  PrefsAddString("cdrom", DEFAULT_CDROM_PATH);
 
   PrefsReplaceInt32("bootdriver", ([bootFrom indexOfSelectedItem] == 1 ? CDROMRefNum : 0));
   PrefsReplaceString("rom", [[romFile stringValue] UTF8String]);

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -121,7 +121,7 @@ static NSString *getStringFromPrefs(const char *key)
   index = 0;
   while ((dsk = PrefsFindString("cdrom", index++)) != NULL) {
     NSString *path = [NSString stringWithUTF8String: dsk ];
-      if(![path isEqualToString:@"/dev/poll/cdrom"]) {
+      if (![path isEqualToString:@"/dev/poll/cdrom"]) {
         DiskType *disk = [[[DiskType alloc] init] autorelease];
         [disk setPath:[NSString stringWithUTF8String: dsk ]];
         [disk setIsCDROM:YES];

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -121,7 +121,7 @@ static NSString *getStringFromPrefs(const char *key)
   index = 0;
   while ((dsk = PrefsFindString("cdrom", index++)) != NULL) {
     NSString *path = [NSString stringWithUTF8String: dsk ];
-	  if (![path hasPrefix:@"/dev/"]) {
+    if (![path hasPrefix:@"/dev/"]) {
         DiskType *disk = [[[DiskType alloc] init] autorelease];
         [disk setPath:[NSString stringWithUTF8String: dsk ]];
         [disk setIsCDROM:YES];
@@ -408,13 +408,12 @@ static NSString *makeRelativeIfNecessary(NSString *path)
     PrefsRemoveItem("disk");
   // Remove all cdroms (but keep the ones in /dev/)
   const char *path;
-  int index=0;
+  int index = 0;
   while ((path = PrefsFindString("cdrom", index)) != NULL) {
 	NSString *p = [NSString stringWithUTF8String: path];
-    if(![p hasPrefix:@"/dev/"]) {
+    if (![p hasPrefix:@"/dev/"]) {
       PrefsRemoveItem("cdrom", index);
-    }
-    else {
+    } else {
       // only increase the index if the current entry has not been deleted
       // if it has been deleted, the next entry is on the current entrys index
       index++;

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -417,6 +417,8 @@ static NSString *makeRelativeIfNecessary(NSString *path)
     PrefsAddString([d isCDROM] ? "cdrom" : "disk", [[d path] UTF8String]);
   }
 
+  PrefsAddString("cdrom", "/dev/poll/cdrom");
+
   PrefsReplaceInt32("bootdriver", ([bootFrom indexOfSelectedItem] == 1 ? CDROMRefNum : 0));
   PrefsReplaceString("rom", [[romFile stringValue] UTF8String]);
   PrefsReplaceString("extfs", [[unixRoot stringValue] UTF8String]);

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -406,18 +406,21 @@ static NSString *makeRelativeIfNecessary(NSString *path)
   // Remove all disks
   while (PrefsFindString("disk"))
     PrefsRemoveItem("disk");
-  // Remove all cdroms
-  while (PrefsFindString("cdrom"))
-    PrefsRemoveItem("cdrom");
-
+  // Remove all cdroms (but keep the ones in /dev/)
+  const char *path;
+  int index=0;
+  while ((path = PrefsFindString("cdrom", index++)) != NULL) {
+	NSString *p = [NSString stringWithUTF8String: path];
+    if(![p hasPrefix:@"/dev/"]) {
+      PrefsRemoveItem("cdrom");
+	}
+  }
 
   // Write all disks
   for (int i = 0; i < [diskArray count]; i++) {
     DiskType *d = [diskArray objectAtIndex:i];
     PrefsAddString([d isCDROM] ? "cdrom" : "disk", [[d path] UTF8String]);
   }
-
-  PrefsAddString("cdrom", "/dev/poll/cdrom");
 
   PrefsReplaceInt32("bootdriver", ([bootFrom indexOfSelectedItem] == 1 ? CDROMRefNum : 0));
   PrefsReplaceString("rom", [[romFile stringValue] UTF8String]);

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -120,11 +120,14 @@ static NSString *getStringFromPrefs(const char *key)
   /* Fetch all CDROMs */
   index = 0;
   while ((dsk = PrefsFindString("cdrom", index++)) != NULL) {
-    DiskType *disk = [[[DiskType alloc] init] autorelease];
-    [disk setPath:[NSString stringWithUTF8String: dsk ]];
-    [disk setIsCDROM:YES];
+    NSString *path = [NSString stringWithUTF8String: dsk ];
+      if(![path isEqualToString:@"/dev/poll/cdrom"]) {
+        DiskType *disk = [[[DiskType alloc] init] autorelease];
+        [disk setPath:[NSString stringWithUTF8String: dsk ]];
+        [disk setIsCDROM:YES];
 
-    [diskArray addObject:disk];
+        [diskArray addObject:disk];
+    }
   }
 
   [disks setDataSource: self];

--- a/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
+++ b/SheepShaver/src/MacOSX/Launcher/VMSettingsController.mm
@@ -409,11 +409,13 @@ static NSString *makeRelativeIfNecessary(NSString *path)
   // Remove all cdroms (but keep the ones in /dev/)
   const char *path;
   int index=0;
-  while ((path = PrefsFindString("cdrom", index++)) != NULL) {
+  while ((path = PrefsFindString("cdrom", index)) != NULL) {
 	NSString *p = [NSString stringWithUTF8String: path];
     if(![p hasPrefix:@"/dev/"]) {
-      PrefsRemoveItem("cdrom");
+      PrefsRemoveItem("cdrom", index);
 	}
+	  
+	index++;
   }
 
   // Write all disks


### PR DESCRIPTION
This should fix #149.

It will still show the ``/dev/poll/cdrom`` entries if they are not configured as cdrom, so that the user can remove those entries.