### PR TITLE
Remove obsolete sg.h workaround.

### DIFF
--- a/BasiliskII/src/Unix/Linux/scsi_linux.cpp
+++ b/BasiliskII/src/Unix/Linux/scsi_linux.cpp
@@ -22,7 +22,7 @@
 
 #include <sys/ioctl.h>
 #include <linux/param.h>
-#include <linux/../scsi/sg.h>	// workaround for broken RedHat 6.0 /usr/include/scsi
+#include <scsi/sg.h>
 #include <unistd.h>
 #include <errno.h>
 


### PR DESCRIPTION
This is no longer necessary as of glibc 2.2 (released in November 2000), and it causes breakage when /usr/include/linux is installed using a symlink-based system like stow.

For more details about what this was originally for, see [sg3_utils' sg_linux_inc.h](https://github.com/hreinecke/sg3_utils/blob/master/include/sg_linux_inc.h#L27).