### PR TITLE
sigsegv.cpp: Add addr32 decode

### DIFF
--- a/BasiliskII/src/CrossPlatform/sigsegv.cpp
+++ b/BasiliskII/src/CrossPlatform/sigsegv.cpp
@@ -1018,6 +1018,14 @@ static bool ix86_skip_instruction(SIGSEGV_REGISTER_TYPE * regs)
 		transfer_size = SIZE_WORD;
 	}
 
+#if defined(__x86_64__) || defined(_M_X64)
+	// addr32
+	if (*eip == 0x67) {
+		eip++;
+		len++;
+	}
+#endif
+
 	// REX prefix
 #if defined(__x86_64__) || defined(_M_X64)
 	struct rex_t {


### PR DESCRIPTION
With this fix I can compile with ./configure --enable-addressing=direct,0x100000
and then I don't need to change vm.mmap_min_addr and hence without root
privileges