### PR TITLE
configure: Enable /dev/ptmx for Linux, Darwin.

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -569,9 +569,6 @@ case "$host" in
 *-*-hpux10.26)
 	disable_ptmx_check=yes
 	;;
-*-*-linux*)
-	no_dev_ptmx=1
-	;;
 mips-sony-bsd|mips-sony-newsos4)
 	AC_DEFINE(HAVE_NEWS4, 1, [Define if you are on NEWS-OS (additions from openssh-3.2.2p1, for sshpty.c).])
 	;;
@@ -585,7 +582,6 @@ mips-sony-bsd|mips-sony-newsos4)
 	no_dev_ptmx=1
 	;;
 *-*-darwin*)
-	no_dev_ptmx=1
 	LIBS="$LIBS -lstdc++"
 	;;
 *-*-freebsd*)


### PR DESCRIPTION
Both of these systems have /dev/ptmx for creating pseudoterminals.
OS X Leopard (10.5) added it in 2007, and Linux has had support for
it since v2.1 (1998).

This fixes a bug with pseudoterminal creation on Linux and macOS
where a new pseudoterminal cannot be created because the wrong
method is being used to find one.