### PR TITLE
src/Unix/Darwin/testlmem.sh: make code shorter

### DIFF
--- a/BasiliskII/src/Unix/Darwin/testlmem.sh
+++ b/BasiliskII/src/Unix/Darwin/testlmem.sh
@@ -20,8 +20,7 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-PAGEZERO_SIZE=0x2000
-[[ -n "$1" ]] && PAGEZERO_SIZE=$1
+PAGEZERO_SIZE=${1:-0x2000}
 # You want all the output to go to stderr so that configure is quiet but
 # config.log is verbose.
 { echo 'building lowmem utility' && \


### PR DESCRIPTION
The old code used the `[[` shell keyword, which is only available in bash.
The interpreter in line 1 is `/bin/sh` though.
This confused my shell portability check in pkgsrc, since that check neither guesses the target platform from the filename, nor assumes that `/bin/sh` is actually bash, even though this may be true on macOS.

The change makes the code shorter with the well-known `${var:-default}` pattern.
Since `$1` is now only accessed when it is defined, this allows the program to have a `set -eu` at the top.
This in turn would make all the `&&` redundant since it applies automatic error checking.

The `{ ... } 1>&2` could also be replaced with a single `exec 1>&2` at the top.