### PR TITLE
linux: x11: enable upscaling

### DIFF
--- a/BasiliskII/src/CrossPlatform/video_vosf.h
+++ b/BasiliskII/src/CrossPlatform/video_vosf.h
@@ -57,7 +57,7 @@
 #define MONITOR_INIT			X11_monitor_desc &monitor
 #define VIDEO_DRV_WIN_INIT		driver_window *drv
 #define VIDEO_DRV_DGA_INIT		driver_dga *drv
-#define VIDEO_DRV_WINDOW		drv->w
+#define VIDEO_DRV_WINDOW		drv->drawable
 #define VIDEO_DRV_GC			drv->gc
 #define VIDEO_DRV_IMAGE			drv->img
 #define VIDEO_DRV_HAVE_SHM		drv->have_shm

--- a/BasiliskII/src/Unix/sshpty.c
+++ b/BasiliskII/src/Unix/sshpty.c
@@ -187,6 +187,7 @@ pty_allocate(int *ptyfd, int *ttyfd, char *namebuf, int namebuflen)
 	 * Push the appropriate streams modules, as described in Solaris pts(7).
 	 * HP-UX pts(7) doesn't have ttcompat module.
 	 */
+#if defined(HAVE_SYS_STROPTS_H)
 	if (ioctl(*ttyfd, I_PUSH, "ptem") < 0)
 		error("ioctl I_PUSH ptem: %.100s", strerror(errno));
 	if (ioctl(*ttyfd, I_PUSH, "ldterm") < 0)
@@ -195,6 +196,7 @@ pty_allocate(int *ptyfd, int *ttyfd, char *namebuf, int namebuflen)
 	if (ioctl(*ttyfd, I_PUSH, "ttcompat") < 0)
 		error("ioctl I_PUSH ttcompat: %.100s", strerror(errno));
 #endif
+#endif /* defined(HAVE_SYS_STROPTS_H) */
 #endif
 	return 1;
 #else /* HAVE_DEV_PTMX */


### PR DESCRIPTION
   Use the XRender extention to add basic x2 upscaling of the video.
    
    On a 4K screen with HiDPI, the video window is tiny and completely
    unreadable. This patch detects HiDPI screen and attempt to upscale by
    x2.
    
    To do that, I change the rendering path so the XImage (local image) is
    drawn into a server XPixmap instead of the window directly (that doesn't
    support scaling)
    
    Then after the X*PutImage is/are done, I use XRenderComposite to draw
    that offscreen pixmap into the window, having applied a Transform to the
    pixmap so it scales up.
    
    The code will only work with the VOSF drawing path at the minute,
    however it /should/ be easy to adapt for the other rendering paths, the
    other path are already compatible with drawing into an offscreen Pixmap
    now (see previous patch).
    