### PR TITLE
For Darwin, the default addressing mode is memory banks.

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -1428,6 +1428,11 @@ fi
 AC_TRANSLATE_DEFINE(HAVE_LINKER_SCRIPT, "$ac_cv_linker_script_works",
   [Define if there is a linker script to relocate the executable above 0x70000000.])
 
+dnl override the addressing mode test order for Darwin
+if [[ "x$OS_TYPE" = "xdarwin" ]]; then
+    ADDRESSING_TEST_ORDER="banks"
+fi
+
 dnl Determine the addressing mode to use
 if [[ "x$WANT_NATIVE_M68K" = "xyes" ]]; then
   ADDRESSING_MODE="real"


### PR DESCRIPTION
When the host OS is Mac OS X, direct addressing in BII doesn't guarantee
that the allocated memory for frame buffer base address in the host
(FrameBaseHost) satisfies the following conditions:

- FrameBaseHost > RamBaseHost
- (FrameBaseHost - RamBaseHost) + Frame_Size < 4GiB
where RamBaseHost refers to the emulated RAM base address in the host.

This may cause the random hang problem where the allocated frame address
failed to meet the conditions above.

Because the direct addressing mapping is a simple math:

RamAddrMac = RamAddrHost - RamBaseHost.

See details: https://github.com/cebix/macemu/issues/203

Signed-off-by: Ricky Zhang <rickyzhang@gmail.com>