### PR TITLE
Enhanced scale up and scale down in SDL2.

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -690,7 +690,7 @@ static SDL_Surface * init_sdl_video(int width, int height, int bpp, Uint32 flags
     
 	int window_width = width;
 	int window_height = height;
-	Uint32 window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
+	Uint32 window_flags = SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE;
 	const int window_flags_to_monitor = SDL_WINDOW_FULLSCREEN;
 	
 	if (flags & SDL_WINDOW_FULLSCREEN) {
@@ -2124,9 +2124,17 @@ static int SDLCALL on_sdl_event_generated(void *userdata, SDL_Event * event)
 						}
 #endif
 					}
-				} break;
+				} break; // end of SDL_WINDOWEVENT_RESIZED
+				case SDL_WINDOWEVENT_RESTORED: {
+					// When the user minimizes the window and then restore it,
+					// we restore the scale factor to 1.
+					if (sdl_window) {
+						const VIDEO_MODE &mode = drv->mode;
+						SDL_SetWindowSize(sdl_window, VIDEO_MODE_X, VIDEO_MODE_Y);
+					}
+				} break; // end of SDL_WINDOWEVENT_RESTORED
 			}
-		} break;
+		} break; // end of SDL_WINDOWEVENT
 	}
 	
 	return EVENT_ADD_TO_QUEUE;


### PR DESCRIPTION
The current SDL2 only scale up in full screen mode. This PR enhance the scale up in window mode. The user can change the scale factor at will by resizing the window.

When user restore the window from minimize or maximize, it restores the scale ratio to 1.

See my demo in [screen cast](https://youtu.be/RzwpeUe787E)