### PR TITLE
Patch SDL2 for System 6 24bit ROM

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -983,15 +983,11 @@ void driver_base::init()
 	// manually set palette for 24bit ROM
 	// 24 bit ROM Macintosh is BW screen. It doesn't setup palette by the ROM.
 	if (TwentyFourBitAddressing && !sdl_palette) {
-		const int nColor = 255;
+		const int nColor = 256;
 		sdl_palette = SDL_AllocPalette(nColor);
 		SDL_Color *p = sdl_palette->colors;
 		for (int i = 0; i < nColor; i++) {
-			if (0 == i %2) {
-				p->r = 0; p->g = 0; p->b = 0;
-			} else {
-				p->r = 255; p->g = 255; p->b = 255;
-			}
+			p->r = p->g = p->b = i;
 			p++;
 		}
 		update_palette();

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -980,6 +980,23 @@ void driver_base::set_video_mode(int flags)
 void driver_base::init()
 {
 	set_video_mode(display_type == DISPLAY_SCREEN ? SDL_WINDOW_FULLSCREEN : 0);
+	// manually set palette for 24bit ROM
+	// 24 bit ROM Macintosh is BW screen. It doesn't setup palette by the ROM.
+	if (TwentyFourBitAddressing && !sdl_palette) {
+		const int nColor = 255;
+		sdl_palette = SDL_AllocPalette(nColor);
+		SDL_Color *p = sdl_palette->colors;
+		for (int i = 0; i < nColor; i++) {
+			if (0 == i %2) {
+				p->r = 0; p->g = 0; p->b = 0;
+			} else {
+				p->r = 255; p->g = 255; p->b = 255;
+			}
+			p++;
+		}
+		update_palette();
+	}
+
 	int aligned_height = (VIDEO_MODE_Y + 15) & ~15;
 
 #ifdef ENABLE_VOSF

--- a/BasiliskII/src/Unix/main_unix.cpp
+++ b/BasiliskII/src/Unix/main_unix.cpp
@@ -672,9 +672,7 @@ int main(int argc, char **argv)
 	RAMBaseMac = Host2MacAddr(RAMBaseHost);
 	ROMBaseMac = Host2MacAddr(ROMBaseHost);
 #endif
-	D(bug("Mac RAM starts at %p (%08x)\n", RAMBaseHost, RAMBaseMac));
-	D(bug("Mac ROM starts at %p (%08x)\n", ROMBaseHost, ROMBaseMac));
-	
+
 #if __MACOSX__
 	extern void set_current_directory();
 	set_current_directory();
@@ -736,6 +734,9 @@ int main(int argc, char **argv)
 	if (!InitAll(vmdir))
 		QuitEmulator();
 	D(bug("Initialization complete\n"));
+
+	D(bug("Mac RAM starts at %p (%08x)\n", RAMBaseHost, RAMBaseMac));
+	D(bug("Mac ROM starts at %p (%08x)\n", ROMBaseHost, ROMBaseMac));
 
 #if !EMULATED_68K
 	// (Virtual) supervisor mode, disable interrupts

--- a/BasiliskII/src/uae_cpu/memory.cpp
+++ b/BasiliskII/src/uae_cpu/memory.cpp
@@ -53,27 +53,27 @@ addrbank mem_banks[65536];
 #ifdef NO_INLINE_MEMORY_ACCESS
 uae_u32 longget (uaecptr addr)
 {
-    return call_mem_get_func (get_mem_bank (addr).lget, addr);
+	return call_mem_get_func (get_mem_bank (addr).lget, addr);
 }
 uae_u32 wordget (uaecptr addr)
 {
-    return call_mem_get_func (get_mem_bank (addr).wget, addr);
+	return call_mem_get_func (get_mem_bank (addr).wget, addr);
 }
 uae_u32 byteget (uaecptr addr)
 {
-    return call_mem_get_func (get_mem_bank (addr).bget, addr);
+	return call_mem_get_func (get_mem_bank (addr).bget, addr);
 }
 void longput (uaecptr addr, uae_u32 l)
 {
-    call_mem_put_func (get_mem_bank (addr).lput, addr, l);
+	call_mem_put_func (get_mem_bank (addr).lput, addr, l);
 }
 void wordput (uaecptr addr, uae_u32 w)
 {
-    call_mem_put_func (get_mem_bank (addr).wput, addr, w);
+	call_mem_put_func (get_mem_bank (addr).wput, addr, w);
 }
 void byteput (uaecptr addr, uae_u32 b)
 {
-    call_mem_put_func (get_mem_bank (addr).bput, addr, b);
+	call_mem_put_func (get_mem_bank (addr).bput, addr, b);
 }
 #endif
 
@@ -88,42 +88,42 @@ static void REGPARAM2 dummy_bput (uaecptr, uae_u32) REGPARAM;
 
 uae_u32 REGPARAM2 dummy_lget (uaecptr addr)
 {
-    if (illegal_mem)
-	write_log ("Illegal lget at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal lget at %08x\n", addr);
 
-    return 0;
+	return 0;
 }
 
 uae_u32 REGPARAM2 dummy_wget (uaecptr addr)
 {
-    if (illegal_mem)
-	write_log ("Illegal wget at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal wget at %08x\n", addr);
 
-    return 0;
+	return 0;
 }
 
 uae_u32 REGPARAM2 dummy_bget (uaecptr addr)
 {
-    if (illegal_mem)
-	write_log ("Illegal bget at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal bget at %08x\n", addr);
 
-    return 0;
+	return 0;
 }
 
 void REGPARAM2 dummy_lput (uaecptr addr, uae_u32 l)
 {
-    if (illegal_mem)
-	write_log ("Illegal lput at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal lput at %08x\n", addr);
 }
 void REGPARAM2 dummy_wput (uaecptr addr, uae_u32 w)
 {
-    if (illegal_mem)
-	write_log ("Illegal wput at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal wput at %08x\n", addr);
 }
 void REGPARAM2 dummy_bput (uaecptr addr, uae_u32 b)
 {
-    if (illegal_mem)
-	write_log ("Illegal bput at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal bput at %08x\n", addr);
 }
 
 /* Mac RAM (32 bit addressing) */
@@ -140,35 +140,35 @@ static uintptr RAMBaseDiff;	// RAMBaseHost - RAMBaseMac
 
 uae_u32 REGPARAM2 ram_lget(uaecptr addr)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(RAMBaseDiff + addr);
-    return do_get_mem_long(m);
+	uae_u32 *m;
+	m = (uae_u32 *)(RAMBaseDiff + addr);
+	return do_get_mem_long(m);
 }
 
 uae_u32 REGPARAM2 ram_wget(uaecptr addr)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(RAMBaseDiff + addr);
-    return do_get_mem_word(m);
+	uae_u16 *m;
+	m = (uae_u16 *)(RAMBaseDiff + addr);
+	return do_get_mem_word(m);
 }
 
 uae_u32 REGPARAM2 ram_bget(uaecptr addr)
 {
-    return (uae_u32)*(uae_u8 *)(RAMBaseDiff + addr);
+	return (uae_u32)*(uae_u8 *)(RAMBaseDiff + addr);
 }
 
 void REGPARAM2 ram_lput(uaecptr addr, uae_u32 l)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(RAMBaseDiff + addr);
-    do_put_mem_long(m, l);
+	uae_u32 *m;
+	m = (uae_u32 *)(RAMBaseDiff + addr);
+	do_put_mem_long(m, l);
 }
 
 void REGPARAM2 ram_wput(uaecptr addr, uae_u32 w)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(RAMBaseDiff + addr);
-    do_put_mem_word(m, w);
+	uae_u16 *m;
+	m = (uae_u16 *)(RAMBaseDiff + addr);
+	do_put_mem_word(m, w);
 }
 
 void REGPARAM2 ram_bput(uaecptr addr, uae_u32 b)
@@ -178,7 +178,7 @@ void REGPARAM2 ram_bput(uaecptr addr, uae_u32 b)
 
 uae_u8 *REGPARAM2 ram_xlate(uaecptr addr)
 {
-    return (uae_u8 *)(RAMBaseDiff + addr);
+	return (uae_u8 *)(RAMBaseDiff + addr);
 }
 
 /* Mac RAM (24 bit addressing) */
@@ -193,35 +193,35 @@ static uae_u8 *REGPARAM2 ram24_xlate(uaecptr addr) REGPARAM;
 
 uae_u32 REGPARAM2 ram24_lget(uaecptr addr)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
-    return do_get_mem_long(m);
+	uae_u32 *m;
+	m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
+	return do_get_mem_long(m);
 }
 
 uae_u32 REGPARAM2 ram24_wget(uaecptr addr)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
-    return do_get_mem_word(m);
+	uae_u16 *m;
+	m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
+	return do_get_mem_word(m);
 }
 
 uae_u32 REGPARAM2 ram24_bget(uaecptr addr)
 {
-    return (uae_u32)*(uae_u8 *)(RAMBaseDiff + (addr & 0xffffff));
+	return (uae_u32)*(uae_u8 *)(RAMBaseDiff + (addr & 0xffffff));
 }
 
 void REGPARAM2 ram24_lput(uaecptr addr, uae_u32 l)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
-    do_put_mem_long(m, l);
+	uae_u32 *m;
+	m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
+	do_put_mem_long(m, l);
 }
 
 void REGPARAM2 ram24_wput(uaecptr addr, uae_u32 w)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
-    do_put_mem_word(m, w);
+	uae_u16 *m;
+	m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
+	do_put_mem_word(m, w);
 }
 
 void REGPARAM2 ram24_bput(uaecptr addr, uae_u32 b)
@@ -231,7 +231,7 @@ void REGPARAM2 ram24_bput(uaecptr addr, uae_u32 b)
 
 uae_u8 *REGPARAM2 ram24_xlate(uaecptr addr)
 {
-    return (uae_u8 *)(RAMBaseDiff + (addr & 0xffffff));
+	return (uae_u8 *)(RAMBaseDiff + (addr & 0xffffff));
 }
 
 /* Mac ROM (32 bit addressing) */
@@ -248,44 +248,44 @@ static uintptr ROMBaseDiff;	// ROMBaseHost - ROMBaseMac
 
 uae_u32 REGPARAM2 rom_lget(uaecptr addr)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(ROMBaseDiff + addr);
-    return do_get_mem_long(m);
+	uae_u32 *m;
+	m = (uae_u32 *)(ROMBaseDiff + addr);
+	return do_get_mem_long(m);
 }
 
 uae_u32 REGPARAM2 rom_wget(uaecptr addr)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(ROMBaseDiff + addr);
-    return do_get_mem_word(m);
+	uae_u16 *m;
+	m = (uae_u16 *)(ROMBaseDiff + addr);
+	return do_get_mem_word(m);
 }
 
 uae_u32 REGPARAM2 rom_bget(uaecptr addr)
 {
-    return (uae_u32)*(uae_u8 *)(ROMBaseDiff + addr);
+	return (uae_u32)*(uae_u8 *)(ROMBaseDiff + addr);
 }
 
 void REGPARAM2 rom_lput(uaecptr addr, uae_u32 b)
 {
-    if (illegal_mem)
-	write_log ("Illegal ROM lput at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal ROM lput at %08x\n", addr);
 }
 
 void REGPARAM2 rom_wput(uaecptr addr, uae_u32 b)
 {
-    if (illegal_mem)
-	write_log ("Illegal ROM wput at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal ROM wput at %08x\n", addr);
 }
 
 void REGPARAM2 rom_bput(uaecptr addr, uae_u32 b)
 {
-    if (illegal_mem)
-	write_log ("Illegal ROM bput at %08x\n", addr);
+	if (illegal_mem)
+		write_log ("Illegal ROM bput at %08x\n", addr);
 }
 
 uae_u8 *REGPARAM2 rom_xlate(uaecptr addr)
 {
-    return (uae_u8 *)(ROMBaseDiff + addr);
+	return (uae_u8 *)(ROMBaseDiff + addr);
 }
 
 /* Mac ROM (24 bit addressing) */
@@ -297,26 +297,26 @@ static uae_u8 *REGPARAM2 rom24_xlate(uaecptr addr) REGPARAM;
 
 uae_u32 REGPARAM2 rom24_lget(uaecptr addr)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(ROMBaseDiff + (addr & 0xffffff));
-    return do_get_mem_long(m);
+	uae_u32 *m;
+	m = (uae_u32 *)(ROMBaseDiff + (addr & 0xffffff));
+	return do_get_mem_long(m);
 }
 
 uae_u32 REGPARAM2 rom24_wget(uaecptr addr)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(ROMBaseDiff + (addr & 0xffffff));
-    return do_get_mem_word(m);
+	uae_u16 *m;
+	m = (uae_u16 *)(ROMBaseDiff + (addr & 0xffffff));
+	return do_get_mem_word(m);
 }
 
 uae_u32 REGPARAM2 rom24_bget(uaecptr addr)
 {
-    return (uae_u32)*(uae_u8 *)(ROMBaseDiff + (addr & 0xffffff));
+	return (uae_u32)*(uae_u8 *)(ROMBaseDiff + (addr & 0xffffff));
 }
 
 uae_u8 *REGPARAM2 rom24_xlate(uaecptr addr)
 {
-    return (uae_u8 *)(ROMBaseDiff + (addr & 0xffffff));
+	return (uae_u8 *)(ROMBaseDiff + (addr & 0xffffff));
 }
 
 /* Frame buffer */
@@ -347,120 +347,120 @@ static uintptr FrameBaseDiff;	// MacFrameBaseHost - MacFrameBaseMac
 
 uae_u32 REGPARAM2 frame_direct_lget(uaecptr addr)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    return do_get_mem_long(m);
+	uae_u32 *m;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	return do_get_mem_long(m);
 }
 
 uae_u32 REGPARAM2 frame_direct_wget(uaecptr addr)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(FrameBaseDiff + addr);
-    return do_get_mem_word(m);
+	uae_u16 *m;
+	m = (uae_u16 *)(FrameBaseDiff + addr);
+	return do_get_mem_word(m);
 }
 
 uae_u32 REGPARAM2 frame_direct_bget(uaecptr addr)
 {
-    return (uae_u32)*(uae_u8 *)(FrameBaseDiff + addr);
+	return (uae_u32)*(uae_u8 *)(FrameBaseDiff + addr);
 }
 
 void REGPARAM2 frame_direct_lput(uaecptr addr, uae_u32 l)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    do_put_mem_long(m, l);
+	uae_u32 *m;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	do_put_mem_long(m, l);
 }
 
 void REGPARAM2 frame_direct_wput(uaecptr addr, uae_u32 w)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(FrameBaseDiff + addr);
-    do_put_mem_word(m, w);
+	uae_u16 *m;
+	m = (uae_u16 *)(FrameBaseDiff + addr);
+	do_put_mem_word(m, w);
 }
 
 void REGPARAM2 frame_direct_bput(uaecptr addr, uae_u32 b)
 {
-    *(uae_u8 *)(FrameBaseDiff + addr) = b;
+	*(uae_u8 *)(FrameBaseDiff + addr) = b;
 }
 
 uae_u32 REGPARAM2 frame_host_555_lget(uaecptr addr)
 {
-    uae_u32 *m, l;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    l = *m;
+	uae_u32 *m, l;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	l = *m;
 	return swap_words(l);
 }
 
 uae_u32 REGPARAM2 frame_host_555_wget(uaecptr addr)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(FrameBaseDiff + addr);
-    return *m;
+	uae_u16 *m;
+	m = (uae_u16 *)(FrameBaseDiff + addr);
+	return *m;
 }
 
 void REGPARAM2 frame_host_555_lput(uaecptr addr, uae_u32 l)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    *m = swap_words(l);
+	uae_u32 *m;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	*m = swap_words(l);
 }
 
 void REGPARAM2 frame_host_555_wput(uaecptr addr, uae_u32 w)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(FrameBaseDiff + addr);
-    *m = w;
+	uae_u16 *m;
+	m = (uae_u16 *)(FrameBaseDiff + addr);
+	*m = w;
 }
 
 uae_u32 REGPARAM2 frame_host_565_lget(uaecptr addr)
 {
-    uae_u32 *m, l;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    l = *m;
-    l = (l & 0x001f001f) | ((l >> 1) & 0x7fe07fe0);
-    return swap_words(l);
+	uae_u32 *m, l;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	l = *m;
+	l = (l & 0x001f001f) | ((l >> 1) & 0x7fe07fe0);
+	return swap_words(l);
 }
 
 uae_u32 REGPARAM2 frame_host_565_wget(uaecptr addr)
 {
-    uae_u16 *m, w;
-    m = (uae_u16 *)(FrameBaseDiff + addr);
-    w = *m;
-    return (w & 0x1f) | ((w >> 1) & 0x7fe0);
+	uae_u16 *m, w;
+	m = (uae_u16 *)(FrameBaseDiff + addr);
+	w = *m;
+	return (w & 0x1f) | ((w >> 1) & 0x7fe0);
 }
 
 void REGPARAM2 frame_host_565_lput(uaecptr addr, uae_u32 l)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    l = (l & 0x001f001f) | ((l << 1) & 0xffc0ffc0);
-    *m = swap_words(l);
+	uae_u32 *m;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	l = (l & 0x001f001f) | ((l << 1) & 0xffc0ffc0);
+	*m = swap_words(l);
 }
 
 void REGPARAM2 frame_host_565_wput(uaecptr addr, uae_u32 w)
 {
-    uae_u16 *m;
-    m = (uae_u16 *)(FrameBaseDiff + addr);
-    *m = (w & 0x1f) | ((w << 1) & 0xffc0);
+	uae_u16 *m;
+	m = (uae_u16 *)(FrameBaseDiff + addr);
+	*m = (w & 0x1f) | ((w << 1) & 0xffc0);
 }
 
 uae_u32 REGPARAM2 frame_host_888_lget(uaecptr addr)
 {
-    uae_u32 *m, l;
-    m = (uae_u32 *)(FrameBaseDiff + addr);
-    return *m;
+	uae_u32 *m, l;
+	m = (uae_u32 *)(FrameBaseDiff + addr);
+	return *m;
 }
 
 void REGPARAM2 frame_host_888_lput(uaecptr addr, uae_u32 l)
 {
-    uae_u32 *m;
-    m = (uae_u32 *)(MacFrameBaseHost + addr - MacFrameBaseMac);
-    *m = l;
+	uae_u32 *m;
+	m = (uae_u32 *)(MacFrameBaseHost + addr - MacFrameBaseMac);
+	*m = l;
 }
 
 uae_u8 *REGPARAM2 frame_xlate(uaecptr addr)
 {
-    return (uae_u8 *)(FrameBaseDiff + addr);
+	return (uae_u8 *)(FrameBaseDiff + addr);
 }
 
 /* Mac framebuffer RAM (24 bit addressing)
@@ -475,110 +475,110 @@ static void REGPARAM2 fram24_bput(uaecptr, uae_u32) REGPARAM;
 
 void REGPARAM2 fram24_lput(uaecptr addr, uae_u32 l)
 {
-    uaecptr page_off = addr & 0xffff;
-    if (0xa700 <= page_off && page_off < 0xfc80) {
-	uae_u32 *fm;
-	fm = (uae_u32 *)(MacFrameBaseHost + page_off - 0xa700);
-	do_put_mem_long(fm, l);
-    }
+	uaecptr page_off = addr & 0xffff;
+	if (0xa700 <= page_off && page_off < 0xfc80) {
+		uae_u32 *fm;
+		fm = (uae_u32 *)(MacFrameBaseHost + page_off - 0xa700);
+		do_put_mem_long(fm, l);
+	}
 
-    uae_u32 *m;
-    m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
-    do_put_mem_long(m, l);
+	uae_u32 *m;
+	m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
+	do_put_mem_long(m, l);
 }
 
 void REGPARAM2 fram24_wput(uaecptr addr, uae_u32 w)
 {
-    uaecptr page_off = addr & 0xffff;
-    if (0xa700 <= page_off && page_off < 0xfc80) {
-	uae_u16 *fm;
-	fm = (uae_u16 *)(MacFrameBaseHost + page_off - 0xa700);
-	do_put_mem_word(fm, w);
-    }
+	uaecptr page_off = addr & 0xffff;
+	if (0xa700 <= page_off && page_off < 0xfc80) {
+		uae_u16 *fm;
+		fm = (uae_u16 *)(MacFrameBaseHost + page_off - 0xa700);
+		do_put_mem_word(fm, w);
+	}
 
-    uae_u16 *m;
-    m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
-    do_put_mem_word(m, w);
+	uae_u16 *m;
+	m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
+	do_put_mem_word(m, w);
 }
 
 void REGPARAM2 fram24_bput(uaecptr addr, uae_u32 b)
 {
-    uaecptr page_off = addr & 0xffff;
-    if (0xa700 <= page_off && page_off < 0xfc80) {
-        *(uae_u8 *)(MacFrameBaseHost + page_off - 0xa700) = b;
-    }
+	uaecptr page_off = addr & 0xffff;
+	if (0xa700 <= page_off && page_off < 0xfc80) {
+		*(uae_u8 *)(MacFrameBaseHost + page_off - 0xa700) = b;
+	}
 
-    *(uae_u8 *)(RAMBaseDiff + (addr & 0xffffff)) = b;
+	*(uae_u8 *)(RAMBaseDiff + (addr & 0xffffff)) = b;
 }
 
 /* Default memory access functions */
 
 uae_u8 *REGPARAM2 default_xlate (uaecptr a)
 {
-    write_log("Your Mac program just did something terribly stupid\n");
-    return NULL;
+	write_log("Your Mac program just did something terribly stupid\n");
+	return NULL;
 }
 
 /* Address banks */
 
 addrbank dummy_bank = {
-    dummy_lget, dummy_wget, dummy_bget,
-    dummy_lput, dummy_wput, dummy_bput,
-    default_xlate
+	dummy_lget, dummy_wget, dummy_bget,
+	dummy_lput, dummy_wput, dummy_bput,
+	default_xlate
 };
 
 addrbank ram_bank = {
-    ram_lget, ram_wget, ram_bget,
-    ram_lput, ram_wput, ram_bput,
-    ram_xlate
+	ram_lget, ram_wget, ram_bget,
+	ram_lput, ram_wput, ram_bput,
+	ram_xlate
 };
 
 addrbank ram24_bank = {
-    ram24_lget, ram24_wget, ram24_bget,
-    ram24_lput, ram24_wput, ram24_bput,
-    ram24_xlate
+	ram24_lget, ram24_wget, ram24_bget,
+	ram24_lput, ram24_wput, ram24_bput,
+	ram24_xlate
 };
 
 addrbank rom_bank = {
-    rom_lget, rom_wget, rom_bget,
-    rom_lput, rom_wput, rom_bput,
-    rom_xlate
+	rom_lget, rom_wget, rom_bget,
+	rom_lput, rom_wput, rom_bput,
+	rom_xlate
 };
 
 addrbank rom24_bank = {
-    rom24_lget, rom24_wget, rom24_bget,
-    rom_lput, rom_wput, rom_bput,
-    rom24_xlate
+	rom24_lget, rom24_wget, rom24_bget,
+	rom_lput, rom_wput, rom_bput,
+	rom24_xlate
 };
 
 addrbank frame_direct_bank = {
-    frame_direct_lget, frame_direct_wget, frame_direct_bget,
-    frame_direct_lput, frame_direct_wput, frame_direct_bput,
-    frame_xlate
+	frame_direct_lget, frame_direct_wget, frame_direct_bget,
+	frame_direct_lput, frame_direct_wput, frame_direct_bput,
+	frame_xlate
 };
 
 addrbank frame_host_555_bank = {
-    frame_host_555_lget, frame_host_555_wget, frame_direct_bget,
-    frame_host_555_lput, frame_host_555_wput, frame_direct_bput,
-    frame_xlate
+	frame_host_555_lget, frame_host_555_wget, frame_direct_bget,
+	frame_host_555_lput, frame_host_555_wput, frame_direct_bput,
+	frame_xlate
 };
 
 addrbank frame_host_565_bank = {
-    frame_host_565_lget, frame_host_565_wget, frame_direct_bget,
-    frame_host_565_lput, frame_host_565_wput, frame_direct_bput,
-    frame_xlate
+	frame_host_565_lget, frame_host_565_wget, frame_direct_bget,
+	frame_host_565_lput, frame_host_565_wput, frame_direct_bput,
+	frame_xlate
 };
 
 addrbank frame_host_888_bank = {
-    frame_host_888_lget, frame_direct_wget, frame_direct_bget,
-    frame_host_888_lput, frame_direct_wput, frame_direct_bput,
-    frame_xlate
+	frame_host_888_lget, frame_direct_wget, frame_direct_bget,
+	frame_host_888_lput, frame_direct_wput, frame_direct_bput,
+	frame_xlate
 };
 
 addrbank fram24_bank = {
-    ram24_lget, ram24_wget, ram24_bget,
-    fram24_lput, fram24_wput, fram24_bput,
-    ram24_xlate
+	ram24_lget, ram24_wget, ram24_bget,
+	fram24_lput, fram24_wput, fram24_bput,
+	ram24_xlate
 };
 
 void memory_init(void)
@@ -604,38 +604,38 @@ void memory_init(void)
 		map_banks(&ram_bank, RAMBaseMac >> 16, ram_size >> 16);
 		map_banks(&rom_bank, ROMBaseMac >> 16, ROMSize >> 16);
 
-                // Map frame buffer
+		// Map frame buffer
 		switch (MacFrameLayout) {
-			case FLAYOUT_DIRECT:
-				map_banks(&frame_direct_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
-				break;
-			case FLAYOUT_HOST_555:
-				map_banks(&frame_host_555_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
-				break;
-			case FLAYOUT_HOST_565:
-				map_banks(&frame_host_565_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
-				break;
-			case FLAYOUT_HOST_888:
-				map_banks(&frame_host_888_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
-				break;
+		case FLAYOUT_DIRECT:
+			map_banks(&frame_direct_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
+			break;
+		case FLAYOUT_HOST_555:
+			map_banks(&frame_host_555_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
+			break;
+		case FLAYOUT_HOST_565:
+			map_banks(&frame_host_565_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
+			break;
+		case FLAYOUT_HOST_888:
+			map_banks(&frame_host_888_bank, MacFrameBaseMac >> 16, (MacFrameSize >> 16) + 1);
+			break;
 		}
 	}
 }
 
 void map_banks(addrbank *bank, int start, int size)
 {
-    int bnr;
-    unsigned long int hioffs = 0, endhioffs = 0x100;
+	int bnr;
+	unsigned long int hioffs = 0, endhioffs = 0x100;
 
-    if (start >= 0x100) {
-	for (bnr = start; bnr < start + size; bnr++)
-	    put_mem_bank (bnr << 16, bank);
-	return;
-    }
-    if (TwentyFourBitAddressing) endhioffs = 0x10000;
-    for (hioffs = 0; hioffs < endhioffs; hioffs += 0x100)
-	for (bnr = start; bnr < start+size; bnr++)
-	    put_mem_bank((bnr + hioffs) << 16, bank);
+	if (start >= 0x100) {
+		for (bnr = start; bnr < start + size; bnr++)
+			put_mem_bank (bnr << 16, bank);
+		return;
+	}
+	if (TwentyFourBitAddressing) endhioffs = 0x10000;
+	for (hioffs = 0; hioffs < endhioffs; hioffs += 0x100)
+		for (bnr = start; bnr < start+size; bnr++)
+			put_mem_bank((bnr + hioffs) << 16, bank);
 }
 
 #endif /* !REAL_ADDRESSING && !DIRECT_ADDRESSING */

--- a/BasiliskII/src/uae_cpu/memory.cpp
+++ b/BasiliskII/src/uae_cpu/memory.cpp
@@ -473,6 +473,34 @@ static void REGPARAM2 fram24_lput(uaecptr, uae_u32) REGPARAM;
 static void REGPARAM2 fram24_wput(uaecptr, uae_u32) REGPARAM;
 static void REGPARAM2 fram24_bput(uaecptr, uae_u32) REGPARAM;
 
+/*
+ * Q: Why the magic number 0xa700 and 0xfc80?
+ *
+ * A: The M68K CPU used by the earlier Macintosh models such as
+ * Macintosh 128K or Macintosh SE, its address space is limited
+ * to 2^24 = 16MiB. The RAM limits to 4MiB.
+ *
+ * With 512x342 1 bit per pixel screen, the size of the frame buffer
+ * is 0x5580 bytes.
+ *
+ * In Macintosh 128K [1], the frame buffer address is mapped from
+ * 0x1A700 to 0x1FC7F.
+ *
+ * In Macintosh SE [2], the frame buffer address is mapped from
+ * 0x3FA700 to 0x3FFC7F.
+ *
+ * The frame24_xxx memory banks mapping used the magic number to
+ * retrieve the offset. The memory write operation does twice:
+ * one for the guest OS and another for the host OS (the write operation
+ * above MacFrameBaseHost).
+ *
+ *
+ * See:
+ *  [1] The Apple Macintosh Computer. http://www.1000bit.it/support/articoli/apple/mac128.pdf
+ *  [2] Capturing Mac SE's video from PDS. http://synack.net/~bbraun/sevideo/
+ *
+ */
+
 void REGPARAM2 fram24_lput(uaecptr addr, uae_u32 l)
 {
 	uaecptr page_off = addr & 0xffff;


### PR DESCRIPTION
The 24bit ROM doesn't invoke video driver control. Therefore, a manual step
is required to add a black & white palette for guest_surface in SDL2.

Please check out [the screen cast here](https://youtu.be/br5Hjt9F6X4).

Also, some other minor changes:

- Fix indentions.
- Move RAM, ROM debug message. The guest OS doesn't populate until init is done. So move it to a better place to show the value.
- Add comment to explain the magic number used in the 24 bit ROM frame buffer mapping.
 
Happy Independence Day!