### PR TITLE
Add autogen for cxmon

### DIFF
--- a/cxmon/autogen.sh
+++ b/cxmon/autogen.sh
@@ -1,0 +1,57 @@
+#! /bin/sh
+# Run this to generate all the initial makefiles, etc.
+# This was lifted from the Gimp, and adapted slightly by
+# Christian Bauer.
+
+DIE=0
+
+PROG="cxmon"
+
+# Check how echo works in this /bin/sh
+case `echo -n` in
+-n) _echo_n=   _echo_c='\c';;
+*)  _echo_n=-n _echo_c=;;
+esac
+
+(autoconf --version) < /dev/null > /dev/null 2>&1 || {
+        echo
+        echo "You must have autoconf installed to compile $PROG."
+        echo "Download the appropriate package for your distribution,"
+        echo "or get the source tarball at ftp://ftp.gnu.org/pub/gnu/"
+        DIE=1
+}
+
+(aclocal --version) < /dev/null > /dev/null 2>&1 || {
+	echo
+	echo "**Error**: Missing aclocal. The version of automake"
+	echo "installed doesn't appear recent enough."
+	echo "Get ftp://ftp.gnu.org/pub/gnu/automake-1.3.tar.gz"
+	echo "(or a newer version if it is available)"
+	DIE=1
+}
+
+if test "$DIE" -eq 1; then
+        exit 1
+fi
+
+aclocalinclude="$ACLOCAL_FLAGS"; \
+(echo $_echo_n " + Running aclocal: $_echo_c"; \
+    aclocal $aclocalinclude; \
+ echo "done.") && \
+(echo $_echo_n " + Running autoheader: $_echo_c"; \
+    autoheader; \
+ echo "done.") && \
+(echo $_echo_n " + Running autoconf: $_echo_c"; \
+    autoconf; \
+ echo "done.") 
+
+rm -f config.cache
+
+if [ x"$NO_CONFIGURE" = "x" ]; then
+    echo " + Running 'configure $@':"
+    if [ -z "$*" ]; then
+        echo "   ** If you wish to pass arguments to ./configure, please"
+        echo "   ** specify them on the command line."
+    fi
+    ./configure "$@"
+fi


### PR DESCRIPTION
The configure file in cxmon is out of dated:

```
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /home/Ricky/repo/github/macemu/cxmon/missing aclocal-1.15 
/home/Ricky/repo/github/macemu/cxmon/missing: line 81: aclocal-1.15: command not found
WARNING: 'aclocal-1.15' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
make: *** [Makefile:367: aclocal.m4] Error 127
```

It needs to reruns autoconf to update configure file. Add autogen.sh to automate the process.

Signed-off-by: Ricky Zhang <rickyzhang@gmail.com>