### PR TITLE
Port mini vMac guest OS screen ROM patch.

### DIFF
--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -98,6 +98,9 @@ const char KEYCODE_FILE_NAME[] = DATADIR "/keycodes";
 const char KEYCODE_FILE_NAME2[] = DATADIR "/BasiliskII_keycodes";
 #endif
 
+// Mac Screen Width and Height
+uint32 MacScreenWidth;
+uint32 MacScreenHeight;
 
 // Global variables
 static uint32 frame_skip;							// Prefs items
@@ -496,7 +499,11 @@ static void set_mac_frame_buffer(SDL_monitor_desc &monitor, int depth, bool nati
 		MacFrameLayout = layout;
 	else
 		MacFrameLayout = FLAYOUT_DIRECT;
-	monitor.set_mac_frame_base(MacFrameBaseMac);
+
+	if (TwentyFourBitAddressing)
+		monitor.set_mac_frame_base(MacFrameBaseMac24Bit);
+	else
+		monitor.set_mac_frame_base(MacFrameBaseMac);
 
 	// Set variables used by UAE memory banking
 	const VIDEO_MODE &mode = monitor.get_current_mode();
@@ -845,6 +852,10 @@ static SDL_Surface * init_sdl_video(int width, int height, int bpp, Uint32 flags
 
 	SDL_RenderSetIntegerScale(sdl_renderer, PrefsFindBool("scale_integer") ? SDL_TRUE : SDL_FALSE);
 
+	// set Mac screen global variabls
+	MacScreenWidth = width;
+	MacScreenHeight = height;
+	D(bug("Set Mac Screen Width: %d, Mac Screen Height: %d\n", MacScreenWidth, MacScreenHeight));
 	return guest_surface;
 }
 
@@ -1367,16 +1378,13 @@ bool VideoInit(bool classic)
 	// Get screen mode from preferences
 	migrate_screen_prefs();
 	const char *mode_str = NULL;
-	if (classic_mode)
-		mode_str = "win/512/342";
-	else
-		mode_str = PrefsFindString("screen");
 
+	mode_str = PrefsFindString("screen");
 	// Determine display type and default dimensions
 	int default_width, default_height;
 	if (classic) {
 		default_width = 512;
-		default_height = 384;
+		default_height = 342;
 	}
 	else {
 		default_width = 640;
@@ -1398,6 +1406,10 @@ bool VideoInit(bool classic)
 	else if (default_height > sdl_display_height())
 		default_height = sdl_display_height();
 
+	// for classic Mac, make sure the display width is 8
+	if (classic) {
+		default_width = (default_width << 3) >> 3;
+	}
 	// Mac screen depth follows X depth
 	screen_depth = 32;
 	SDL_DisplayMode desktop_mode;
@@ -1457,7 +1469,7 @@ bool VideoInit(bool classic)
 	// Construct list of supported modes
 	if (display_type == DISPLAY_WINDOW) {
 		if (classic)
-			add_mode(display_type, 512, 342, 0x80, 64, VIDEO_DEPTH_1BIT);
+			add_mode(display_type, default_width, default_height, 0x80, default_width/8, VIDEO_DEPTH_1BIT);
 		else {
 			for (int i = 0; video_modes[i].w != 0; i++) {
 				const int w = video_modes[i].w;

--- a/BasiliskII/src/include/video.h
+++ b/BasiliskII/src/include/video.h
@@ -253,7 +253,10 @@ public:
 
 // Vector of pointers to available monitor descriptions, filled by VideoInit()
 extern vector<monitor_desc *> VideoMonitors;
-
+// Guest OS Screen Width
+extern uint32 MacScreenWidth;
+// Guest OS Screen Height
+extern uint32 MacScreenHeight;
 
 extern int16 VideoDriverOpen(uint32 pb, uint32 dce);
 extern int16 VideoDriverControl(uint32 pb, uint32 dce);

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -1008,6 +1008,179 @@ static bool patch_rom_classic(void)
 	*wp++ = htons(M68K_EMUL_OP_IRQ);
 	*wp++ = htons(0x4a80);		// tst.l	d0
 	*wp = htons(0x67f4);		// beq		0x402be2
+
+
+	// Patch guest screen for an arbitary resolution
+	// We are going to steal the ROM space that runs RAM test
+	uint32 patchCodeBaseMac; 	// a stateful variable to keep track of the stolen location of the patched code in guest memory.
+	uint16* patchwp; 					// a stateful word pointer pointing to the patch code in host memory.
+	uint32* patchlp;					// a stateful long pointer pointing to the patch code in host memory.
+
+	uint32* lp;								// a statless long pointer
+
+	wp = (uint16 *)(ROMBaseHost + 0x5ca); // start to patch P_mInitVideoGlobal route
+	*wp++ = htons(0x4eb9); /* JSR */
+	lp = (uint32 *)wp;
+
+	const uint32 patchCodeOffset = 0x1d3e; // we steal P_mRamTest routine space
+	patchCodeBaseMac = ROMBaseMac + patchCodeOffset;
+	uint8* patchCodeBaseHost = ROMBaseHost + patchCodeOffset;
+	*lp++ = htonl(patchCodeBaseMac); // we JSR to this Mac address
+	wp = (uint16 *)lp;
+
+	patchwp = (uint16 *)(patchCodeBaseHost); // the host address for the patch
+	// MOVE.L $MacFrameBaseMac24Bit, ($ScrnBase)
+	*patchwp++ = htons(0x21fc); /* MOVE.L */
+	patchCodeBaseMac += 2;
+
+	patchlp = (uint32 *)patchwp;
+	*patchlp++ = htonl(MacFrameBaseMac24Bit);
+	patchCodeBaseMac += 4;
+
+	patchwp = (uint16 *)patchlp;
+	*patchwp++ = htons(0x0824); /* (ScrnBase) */
+	patchCodeBaseMac += 2;
+
+	*patchwp++ = htons(0x4e75); /* RTS */
+	patchCodeBaseMac += 2;
+	patchlp = (uint32 *)patchwp; // keep in sync
+
+	// continue to patch P_mInitVideoGlobal routine
+	wp = (uint16 *)(ROMBaseHost + 0x5d2);
+	*wp = htons(MacScreenWidth / 8);
+	wp = (uint16 *)(ROMBaseHost + 0x60a);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x60e);
+	*wp = htons(MacScreenWidth);
+
+	wp = (uint16 *)(ROMBaseHost + 0x8cc);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x8ce);
+	*wp = htons(MacScreenWidth);
+
+	// blink floppy, disk icon
+	lp = (uint32 *)(ROMBaseHost + 0xf4c);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth
+								 + (MacScreenWidth / 2 - 16))
+									 / 8);
+	// blink floppy, question mark
+	lp = (uint32 *)(ROMBaseHost + 0xf5e);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 10) * MacScreenWidth
+								+ (MacScreenWidth / 2 - 8))
+								/ 8);
+
+	lp = (uint32 *)(ROMBaseHost + 0x10a2);
+	*lp = htonl(MacFrameBaseMac24Bit);
+	wp = (uint16 *)(ROMBaseHost + 0x10a8);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x10ac);
+	*wp = htons(MacScreenWidth);
+	wp = (uint16 *)(ROMBaseHost + 0x10b0);
+	*wp = htons(MacScreenWidth / 8);
+	lp = (uint32 *)(ROMBaseHost + 0x10b4);
+	*lp = htonl(MacScreenWidth * MacScreenHeight / 8);// # of bytes in screen
+
+	// sad mac, mac icon
+	lp = (uint32 *)(ROMBaseHost + 0x118a);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth
+								+ (MacScreenWidth / 2 - 16))
+								/ 8);
+	// sad mac, frown
+	lp = (uint32 *)(ROMBaseHost + 0x1198);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 19) * MacScreenWidth
+								+ (MacScreenWidth / 2 - 8))
+								/ 8);
+	wp = (uint16 *)(ROMBaseHost + 0x11b0);
+	*wp = htons(MacScreenWidth / 8);
+
+	// blink floppy and sadmac, position
+	wp = (uint16 *)(ROMBaseHost + 0x11d8);
+	*wp = htons(MacScreenWidth / 8);
+	wp = (uint16 *)(ROMBaseHost + 0x11ea);
+	*wp = htons(MacScreenWidth / 8);
+
+	// cursor handling
+	if (MacScreenWidth >= 1024)
+	{
+		wp = (uint16 *)(ROMBaseHost + 0x18dfe); // start to patch P_HideCursor routine
+		*wp++ = htons(0x4eb9); /* JSR */
+		lp = (uint32 *)wp;
+		*lp++ = htonl(patchCodeBaseMac);
+		wp = (uint16 *)lp;
+
+		*patchwp++ = htons(0x41f8); /* Lea.L (CrsrSave),A0 */
+		patchCodeBaseMac += 2;
+		*patchwp++ = htons(0x088c);
+		patchCodeBaseMac += 2;
+
+		*patchwp++ = htons(0x203c); /* MOVE.L #$x,D0 */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp;
+		*patchlp++ = htonl(MacScreenWidth / 8);
+		patchCodeBaseMac += 4;
+		patchwp = (uint16 *)patchlp;
+
+		*patchwp++ = htons(0x4e75); /* RTS */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp; // keep in sync
+	} else
+	{
+		// P_HideCursor
+		wp = (uint16 *)(ROMBaseHost + 0x18e02);
+		*wp = htons(0x7000 + (MacScreenWidth / 8));
+	} // end if (MacScreenWidth >= 1024)
+
+	wp = (uint16 *)(ROMBaseHost + 0x18e7a);
+	*wp = htons(MacScreenWidth - 32);
+	wp = (uint16 *)(ROMBaseHost + 0x18e80);
+	*wp = htons(MacScreenWidth - 32);
+	wp = (uint16 *)(ROMBaseHost + 0x18ea0);
+	*wp = htons(MacScreenHeight - 16);
+	wp = (uint16 *)(ROMBaseHost + 0x18ea6);
+	*wp = htons(MacScreenHeight);
+
+	if (MacScreenWidth >= 1024)
+	{
+		wp = (uint16 *)(ROMBaseHost + 0x18ec4); // start to patch P_ShowCursor routine
+		*wp++ = htons(0x4eb9); /* JSR */
+		lp = (uint32 *)wp;
+		*lp++ = htonl(patchCodeBaseMac);
+		wp = (uint16 *)lp;
+
+		*patchwp++ = htons(0x2a3c); /* MOVE.L #$x, D5 */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp;
+		*patchlp++ = htonl(MacScreenWidth / 8);
+		patchCodeBaseMac += 4;
+		patchwp = (uint16 *)patchlp;
+
+		*patchwp++ = htons(0xc2c5); /* MulU      D5, D1 */
+		patchCodeBaseMac += 2;
+
+		*patchwp++ = htons(0xd3c1); /* AddA.L    D1, A1 */
+		patchCodeBaseMac += 2;
+
+		*patchwp++ = htons(0x4e75); /* RTS */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp; // keep in sync
+	} else
+	{
+		wp = (uint16 *)(ROMBaseHost + 0x18ec4);
+		*wp = htons(0x7A00 + (MacScreenWidth / 8));
+	}// end if (MacScreenWidth >= 1024)
+
+	// set up screen bitmap
+	wp = (uint16 *)(ROMBaseHost + 0x18f9a);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x18fa0);
+	*wp = htons(MacScreenWidth);
+	wp = (uint16 *)(ROMBaseHost + 0x18fb4);
+	*wp = htons(MacScreenHeight);
+
 	return true;
 }
 

--- a/BasiliskII/src/uae_cpu/cpu_emulation.h
+++ b/BasiliskII/src/uae_cpu/cpu_emulation.h
@@ -42,6 +42,9 @@ extern uint32 ROMSize;			// Size of ROM
 // mapped to this location. The memory must be allocated by VideoInit().
 // If multiple monitors are used, they must share the frame buffer
 const uint32 MacFrameBaseMac = 0xa0000000;
+// For 24 Bit ROM, we maps the guest OS frame buffer address above 4MiB RAM
+// and ROM but less than 16 MiB.
+const uint32 MacFrameBaseMac24Bit = 0x00500000;
 extern uint8 *MacFrameBaseHost;	// Frame buffer base (host address space)
 extern uint32 MacFrameSize;		// Size of frame buffer
 #endif

--- a/BasiliskII/src/uae_cpu/memory.cpp
+++ b/BasiliskII/src/uae_cpu/memory.cpp
@@ -463,15 +463,13 @@ uae_u8 *REGPARAM2 frame_xlate(uaecptr addr)
 	return (uae_u8 *)(FrameBaseDiff + addr);
 }
 
-/* Mac framebuffer RAM (24 bit addressing)
- *
- * This works by duplicating appropriate writes to the 32-bit
- * address-space framebuffer.
- */
-
-static void REGPARAM2 fram24_lput(uaecptr, uae_u32) REGPARAM;
-static void REGPARAM2 fram24_wput(uaecptr, uae_u32) REGPARAM;
-static void REGPARAM2 fram24_bput(uaecptr, uae_u32) REGPARAM;
+/* Mac framebuffer RAM (24 bit addressing) */
+static uae_u32 REGPARAM2 frame24_lget(uaecptr) REGPARAM;
+static uae_u32 REGPARAM2 frame24_wget(uaecptr) REGPARAM;
+static uae_u32 REGPARAM2 frame24_bget(uaecptr) REGPARAM;
+static void REGPARAM2 frame24_lput(uaecptr, uae_u32) REGPARAM;
+static void REGPARAM2 frame24_wput(uaecptr, uae_u32) REGPARAM;
+static void REGPARAM2 frame24_bput(uaecptr, uae_u32) REGPARAM;
 
 /*
  * Q: Why the magic number 0xa700 and 0xfc80?
@@ -501,42 +499,42 @@ static void REGPARAM2 fram24_bput(uaecptr, uae_u32) REGPARAM;
  *
  */
 
-void REGPARAM2 fram24_lput(uaecptr addr, uae_u32 l)
+uae_u32 REGPARAM2 frame24_lget(uaecptr addr)
 {
-	uaecptr page_off = addr & 0xffff;
-	if (0xa700 <= page_off && page_off < 0xfc80) {
-		uae_u32 *fm;
-		fm = (uae_u32 *)(MacFrameBaseHost + page_off - 0xa700);
-		do_put_mem_long(fm, l);
-	}
-
 	uae_u32 *m;
-	m = (uae_u32 *)(RAMBaseDiff + (addr & 0xffffff));
+	m = (uae_u32 *)(FrameBaseDiff + (addr & 0xffffff));
+	return do_get_mem_long(m);
+}
+
+uae_u32 REGPARAM2 frame24_wget(uaecptr addr)
+{
+	uae_u16 *m;
+	m = (uae_u16 *)(FrameBaseDiff + (addr & 0xffffff));
+	return do_get_mem_word(m);
+}
+
+uae_u32 REGPARAM2 frame24_bget(uaecptr addr)
+{
+	return (uae_u32)*(uae_u8 *)(FrameBaseDiff + (addr & 0xffffff));
+}
+
+void REGPARAM2 frame24_lput(uaecptr addr, uae_u32 l)
+{
+	uae_u32 *m;
+	m = (uae_u32 *)(FrameBaseDiff + (addr & 0xffffffff));
 	do_put_mem_long(m, l);
 }
 
-void REGPARAM2 fram24_wput(uaecptr addr, uae_u32 w)
+void REGPARAM2 frame24_wput(uaecptr addr, uae_u32 w)
 {
-	uaecptr page_off = addr & 0xffff;
-	if (0xa700 <= page_off && page_off < 0xfc80) {
-		uae_u16 *fm;
-		fm = (uae_u16 *)(MacFrameBaseHost + page_off - 0xa700);
-		do_put_mem_word(fm, w);
-	}
-
 	uae_u16 *m;
-	m = (uae_u16 *)(RAMBaseDiff + (addr & 0xffffff));
+	m = (uae_u16 *)(FrameBaseDiff + (addr & 0xffffffff));
 	do_put_mem_word(m, w);
 }
 
-void REGPARAM2 fram24_bput(uaecptr addr, uae_u32 b)
+void REGPARAM2 frame24_bput(uaecptr addr, uae_u32 b)
 {
-	uaecptr page_off = addr & 0xffff;
-	if (0xa700 <= page_off && page_off < 0xfc80) {
-		*(uae_u8 *)(MacFrameBaseHost + page_off - 0xa700) = b;
-	}
-
-	*(uae_u8 *)(RAMBaseDiff + (addr & 0xffffff)) = b;
+	*(uae_u8 *)(FrameBaseDiff + (addr & 0xffffffff)) = b;
 }
 
 /* Default memory access functions */
@@ -603,10 +601,10 @@ addrbank frame_host_888_bank = {
 	frame_xlate
 };
 
-addrbank fram24_bank = {
-	ram24_lget, ram24_wget, ram24_bget,
-	fram24_lput, fram24_wput, fram24_bput,
-	ram24_xlate
+addrbank frame24_bank = {
+	frame24_lget, frame24_wget, frame24_bget,
+	frame24_lput, frame24_wput, frame24_bput,
+	default_xlate
 };
 
 void memory_init(void)
@@ -619,15 +617,21 @@ void memory_init(void)
 
 	RAMBaseDiff = (uintptr)RAMBaseHost - (uintptr)RAMBaseMac;
 	ROMBaseDiff = (uintptr)ROMBaseHost - (uintptr)ROMBaseMac;
-	FrameBaseDiff = (uintptr)MacFrameBaseHost - (uintptr)MacFrameBaseMac;
+	if (TwentyFourBitAddressing)
+		FrameBaseDiff = (uintptr)MacFrameBaseHost - (uintptr)MacFrameBaseMac24Bit;
+	else
+		FrameBaseDiff = (uintptr)MacFrameBaseHost - (uintptr)MacFrameBaseMac;
 
+	printf("MacFrameBaseHost: %p, MacFraemBaseMac: %p\n", (uintptr)MacFrameBaseHost, (uintptr)MacFrameBaseMac24Bit);
+	printf("RAMBaseDiff: %p, ROMBaseDiff: %p, FrameBaseDiff: %p, MacFrameSize: %d\n",
+				 RAMBaseDiff, ROMBaseDiff, FrameBaseDiff, MacFrameSize);
 	// Map RAM, ROM and display
 	if (TwentyFourBitAddressing) {
 		map_banks(&ram24_bank, RAMBaseMac >> 16, ram_size >> 16);
 		map_banks(&rom24_bank, ROMBaseMac >> 16, ROMSize >> 16);
 
 		// Map frame buffer at end of RAM.
-		map_banks(&fram24_bank, ((RAMBaseMac + ram_size) >> 16) - 1, 1);
+		map_banks(&frame24_bank, MacFrameBaseMac24Bit >> 16, (MacFrameSize >> 16) + 1);
 	} else {
 		map_banks(&ram_bank, RAMBaseMac >> 16, ram_size >> 16);
 		map_banks(&rom_bank, ROMBaseMac >> 16, ROMSize >> 16);


### PR DESCRIPTION
- Added Mac SE 24 bit ROM screen patch from mini vMac.
  The guest OS resolution in System 6 can be defined
  at an arbitrary combination.
- Mac frame buffer base mapping is moved out from guest RAM.
  This creates more leg room for the host frame buffer.

See my [screen cast demo here](https://youtu.be/aXzM8t_u3zI)

Signed-off-by: Ricky Zhang <rickyzhang@gmail.com>