### PR TITLE
Port mini vMac guest OS screen ROM patch.

### DIFF
--- a/BasiliskII/src/SDL/video_sdl.cpp
+++ b/BasiliskII/src/SDL/video_sdl.cpp
@@ -1033,9 +1033,9 @@ bool VideoInit(bool classic)
 	else if (default_height > sdl_display_height())
 		default_height = sdl_display_height();
 
-	// for classic Mac, make sure the display width is 8
+	// for classic Mac, make sure the display width is divisible by 8
 	if (classic) {
-		default_width = (default_width << 3) >> 3;
+		default_width = (default_width / 8) * 8;
 	}
 
 	// Mac screen depth follows X depth

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -98,6 +98,9 @@ const char KEYCODE_FILE_NAME[] = DATADIR "/keycodes";
 const char KEYCODE_FILE_NAME2[] = DATADIR "/BasiliskII_keycodes";
 #endif
 
+// Mac Screen Width and Height
+uint32 MacScreenWidth;
+uint32 MacScreenHeight;
 
 // Global variables
 static uint32 frame_skip;							// Prefs items
@@ -496,7 +499,11 @@ static void set_mac_frame_buffer(SDL_monitor_desc &monitor, int depth, bool nati
 		MacFrameLayout = layout;
 	else
 		MacFrameLayout = FLAYOUT_DIRECT;
-	monitor.set_mac_frame_base(MacFrameBaseMac);
+
+	if (TwentyFourBitAddressing)
+		monitor.set_mac_frame_base(MacFrameBaseMac24Bit);
+	else
+		monitor.set_mac_frame_base(MacFrameBaseMac);
 
 	// Set variables used by UAE memory banking
 	const VIDEO_MODE &mode = monitor.get_current_mode();
@@ -845,6 +852,10 @@ static SDL_Surface * init_sdl_video(int width, int height, int bpp, Uint32 flags
 
 	SDL_RenderSetIntegerScale(sdl_renderer, PrefsFindBool("scale_integer") ? SDL_TRUE : SDL_FALSE);
 
+	// set Mac screen global variabls
+	MacScreenWidth = width;
+	MacScreenHeight = height;
+	D(bug("Set Mac Screen Width: %d, Mac Screen Height: %d\n", MacScreenWidth, MacScreenHeight));
 	return guest_surface;
 }
 
@@ -1367,16 +1378,13 @@ bool VideoInit(bool classic)
 	// Get screen mode from preferences
 	migrate_screen_prefs();
 	const char *mode_str = NULL;
-	if (classic_mode)
-		mode_str = "win/512/342";
-	else
-		mode_str = PrefsFindString("screen");
 
+	mode_str = PrefsFindString("screen");
 	// Determine display type and default dimensions
 	int default_width, default_height;
 	if (classic) {
 		default_width = 512;
-		default_height = 384;
+		default_height = 342;
 	}
 	else {
 		default_width = 640;
@@ -1398,6 +1406,10 @@ bool VideoInit(bool classic)
 	else if (default_height > sdl_display_height())
 		default_height = sdl_display_height();
 
+	// for classic Mac, make sure the display width is 8
+	if (classic) {
+		default_width = (default_width << 3) >> 3;
+	}
 	// Mac screen depth follows X depth
 	screen_depth = 32;
 	SDL_DisplayMode desktop_mode;
@@ -1457,7 +1469,7 @@ bool VideoInit(bool classic)
 	// Construct list of supported modes
 	if (display_type == DISPLAY_WINDOW) {
 		if (classic)
-			add_mode(display_type, 512, 342, 0x80, 64, VIDEO_DEPTH_1BIT);
+			add_mode(display_type, default_width, default_height, 0x80, default_width/8, VIDEO_DEPTH_1BIT);
 		else {
 			for (int i = 0; video_modes[i].w != 0; i++) {
 				const int w = video_modes[i].w;

--- a/BasiliskII/src/SDL/video_sdl2.cpp
+++ b/BasiliskII/src/SDL/video_sdl2.cpp
@@ -1406,9 +1406,9 @@ bool VideoInit(bool classic)
 	else if (default_height > sdl_display_height())
 		default_height = sdl_display_height();
 
-	// for classic Mac, make sure the display width is 8
+	// for classic Mac, make sure the display width is divisible by 8
 	if (classic) {
-		default_width = (default_width << 3) >> 3;
+		default_width = (default_width / 8) * 8;
 	}
 	// Mac screen depth follows X depth
 	screen_depth = 32;

--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -1808,9 +1808,9 @@ bool VideoInit(bool classic)
 	else if (default_height > DisplayHeight(x_display, screen))
 		default_height = DisplayHeight(x_display, screen);
 
-	// for classic Mac, make sure the display width is 8
+	// for classic Mac, make sure the display width is divisible by 8
 	if (classic) {
-		default_width = (default_width << 3) >> 3;
+		default_width = (default_width / 8) * 8;
 	}
 
 	// Mac screen depth follows X depth

--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -1780,7 +1780,7 @@ bool VideoInit(bool classic)
 	if (classic) {
 		default_width = 512;
 		default_height = 342;
-	}	else {
+	} else {
 		default_width = 640;
 		default_height = 480;
 	}

--- a/BasiliskII/src/Unix/video_x.cpp
+++ b/BasiliskII/src/Unix/video_x.cpp
@@ -84,6 +84,9 @@ const char KEYCODE_FILE_NAME[] = DATADIR "/keycodes";
 static const int win_eventmask = KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | PointerMotionMask | EnterWindowMask | ExposureMask | StructureNotifyMask;
 static const int dga_eventmask = KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | PointerMotionMask | StructureNotifyMask;
 
+// Mac Screen Width and Height
+uint32 MacScreenWidth;
+uint32 MacScreenHeight;
 
 // Global variables
 static int32 frame_skip;							// Prefs items
@@ -416,7 +419,10 @@ static void set_mac_frame_buffer(X11_monitor_desc &monitor, video_depth depth, b
 		MacFrameLayout = layout;
 	else
 		MacFrameLayout = FLAYOUT_DIRECT;
-	monitor.set_mac_frame_base(MacFrameBaseMac);
+	if (TwentyFourBitAddressing)
+		monitor.set_mac_frame_base(MacFrameBaseMac24Bit);
+	else
+		monitor.set_mac_frame_base(MacFrameBaseMac);
 
 	// Set variables used by UAE memory banking
 	const video_mode &mode = monitor.get_current_mode();
@@ -1547,6 +1553,10 @@ bool X11_monitor_desc::video_open(void)
 {
 	D(bug("video_open()\n"));
 	const video_mode &mode = get_current_mode();
+	// set Mac screen global variabls
+	MacScreenWidth = VIDEO_MODE_X;
+	MacScreenHeight = VIDEO_MODE_Y;
+	D(bug("Set Mac Screen Width: %d, Mac Screen Height: %d\n", MacScreenWidth, MacScreenHeight));
 
 	// Find best available X visual
 	if (!find_visual_for_depth(mode.depth)) {
@@ -1763,13 +1773,17 @@ bool VideoInit(bool classic)
 
 	// Get screen mode from preferences
 	const char *mode_str;
-	if (classic_mode)
-		mode_str = "win/512/342";
-	else
-		mode_str = PrefsFindString("screen");
+	mode_str = PrefsFindString("screen");
 
 	// Determine display type and default dimensions
-	int default_width = 512, default_height = 384;
+	int default_width, default_height;
+	if (classic) {
+		default_width = 512;
+		default_height = 342;
+	}	else {
+		default_width = 640;
+		default_height = 480;
+	}
 	display_type = DISPLAY_WINDOW;
 	if (mode_str) {
 		if (sscanf(mode_str, "win/%d/%d", &default_width, &default_height) == 2) {
@@ -1794,6 +1808,11 @@ bool VideoInit(bool classic)
 	else if (default_height > DisplayHeight(x_display, screen))
 		default_height = DisplayHeight(x_display, screen);
 
+	// for classic Mac, make sure the display width is 8
+	if (classic) {
+		default_width = (default_width << 3) >> 3;
+	}
+
 	// Mac screen depth follows X depth
 	video_depth default_depth = VDEPTH_1BIT;
 	switch (DefaultDepth(x_display, screen)) {
@@ -1811,7 +1830,7 @@ bool VideoInit(bool classic)
 	// Construct list of supported modes
 	if (display_type == DISPLAY_WINDOW) {
 		if (classic)
-			add_mode(512, 342, 0x80, 64, VDEPTH_1BIT);
+			add_mode(default_width, default_height, 0x80, default_width/8, VDEPTH_1BIT);
 		else {
 			for (unsigned d=VDEPTH_1BIT; d<=VDEPTH_32BIT; d++) {
 				if (find_visual_for_depth(video_depth(d)))

--- a/BasiliskII/src/include/video.h
+++ b/BasiliskII/src/include/video.h
@@ -253,7 +253,10 @@ public:
 
 // Vector of pointers to available monitor descriptions, filled by VideoInit()
 extern vector<monitor_desc *> VideoMonitors;
-
+// Guest OS Screen Width
+extern uint32 MacScreenWidth;
+// Guest OS Screen Height
+extern uint32 MacScreenHeight;
 
 extern int16 VideoDriverOpen(uint32 pb, uint32 dce);
 extern int16 VideoDriverControl(uint32 pb, uint32 dce);

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -1010,25 +1010,35 @@ static bool patch_rom_classic(void)
 	*wp = htons(0x67f4);		// beq		0x402be2
 
 
-	// Patch guest screen for an arbitary resolution
-	// We are going to steal the ROM space that runs RAM test
-	uint32 patchCodeBaseMac; 	// a stateful variable to keep track of the stolen location of the patched code in guest memory.
-	uint16* patchwp; 					// a stateful word pointer pointing to the patch code in host memory.
-	uint32* patchlp;					// a stateful long pointer pointing to the patch code in host memory.
+	// Patch the guest screen for an arbitary resolution
+	// We are going to steal the abandoned ROM space that runs RAM test
+	// for patching ROM.
 
-	uint32* lp;								// a statless long pointer
+	// a stateful variable to keep track of the stolen location
+	// of the patched code in guest memory.
+	uint32 patchCodeBaseMac;
+	// a stateful word pointer pointing to the patch code in host memory.
+	uint16* patchwp;
+	// a stateful long pointer pointing to the patch code in host memory.
+	uint32* patchlp;
+	// a statless long pointer
+	uint32* lp;
 
-	wp = (uint16 *)(ROMBaseHost + 0x5ca); // start to patch P_mInitVideoGlobal route
+	// start to patch P_mInitVideoGlobal route
+	wp = (uint16 *)(ROMBaseHost + 0x5ca);
 	*wp++ = htons(0x4eb9); /* JSR */
 	lp = (uint32 *)wp;
 
-	const uint32 patchCodeOffset = 0x1d3e; // we steal P_mRamTest routine space
+	// we steal P_mRamTest routine space
+	const uint32 patchCodeOffset = 0x1d3e;
 	patchCodeBaseMac = ROMBaseMac + patchCodeOffset;
 	uint8* patchCodeBaseHost = ROMBaseHost + patchCodeOffset;
-	*lp++ = htonl(patchCodeBaseMac); // we JSR to this Mac address
+	// we JSR to this Mac address
+	*lp++ = htonl(patchCodeBaseMac);
 	wp = (uint16 *)lp;
 
-	patchwp = (uint16 *)(patchCodeBaseHost); // the host address for the patch
+	// the host address for the patch
+	patchwp = (uint16 *)(patchCodeBaseHost);
 	// MOVE.L $MacFrameBaseMac24Bit, ($ScrnBase)
 	*patchwp++ = htons(0x21fc); /* MOVE.L */
 	patchCodeBaseMac += 2;
@@ -1043,7 +1053,8 @@ static bool patch_rom_classic(void)
 
 	*patchwp++ = htons(0x4e75); /* RTS */
 	patchCodeBaseMac += 2;
-	patchlp = (uint32 *)patchwp; // keep in sync
+	// keep in sync
+	patchlp = (uint32 *)patchwp;
 
 	// continue to patch P_mInitVideoGlobal routine
 	wp = (uint16 *)(ROMBaseHost + 0x5d2);
@@ -1080,7 +1091,8 @@ static bool patch_rom_classic(void)
 	wp = (uint16 *)(ROMBaseHost + 0x10b0);
 	*wp = htons(MacScreenWidth / 8);
 	lp = (uint32 *)(ROMBaseHost + 0x10b4);
-	*lp = htonl(MacScreenWidth * MacScreenHeight / 8);// # of bytes in screen
+	// # of bytes in screen
+	*lp = htonl(MacScreenWidth * MacScreenHeight / 8);
 
 	// sad mac, mac icon
 	lp = (uint32 *)(ROMBaseHost + 0x118a);
@@ -1106,7 +1118,8 @@ static bool patch_rom_classic(void)
 	// cursor handling
 	if (MacScreenWidth >= 1024)
 	{
-		wp = (uint16 *)(ROMBaseHost + 0x18dfe); // start to patch P_HideCursor routine
+		// start to patch P_HideCursor routine
+		wp = (uint16 *)(ROMBaseHost + 0x18dfe);
 		*wp++ = htons(0x4eb9); /* JSR */
 		lp = (uint32 *)wp;
 		*lp++ = htonl(patchCodeBaseMac);
@@ -1145,7 +1158,8 @@ static bool patch_rom_classic(void)
 
 	if (MacScreenWidth >= 1024)
 	{
-		wp = (uint16 *)(ROMBaseHost + 0x18ec4); // start to patch P_ShowCursor routine
+		// start to patch P_ShowCursor routine
+		wp = (uint16 *)(ROMBaseHost + 0x18ec4);
 		*wp++ = htons(0x4eb9); /* JSR */
 		lp = (uint32 *)wp;
 		*lp++ = htonl(patchCodeBaseMac);
@@ -1166,7 +1180,8 @@ static bool patch_rom_classic(void)
 
 		*patchwp++ = htons(0x4e75); /* RTS */
 		patchCodeBaseMac += 2;
-		patchlp = (uint32 *)patchwp; // keep in sync
+		// keep in sync
+		patchlp = (uint32 *)patchwp;
 	} else
 	{
 		wp = (uint16 *)(ROMBaseHost + 0x18ec4);

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -1071,16 +1071,10 @@ static bool patch_rom_classic(void)
 
 	// blink floppy, disk icon
 	lp = (uint32 *)(ROMBaseHost + 0xf4c);
-	*lp = htonl(MacFrameBaseMac24Bit
-							+ (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth
-								 + (MacScreenWidth / 2 - 16))
-									 / 8);
+	*lp = htonl(MacFrameBaseMac24Bit + (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth + (MacScreenWidth / 2 - 16)) / 8);
 	// blink floppy, question mark
 	lp = (uint32 *)(ROMBaseHost + 0xf5e);
-	*lp = htonl(MacFrameBaseMac24Bit
-							+ (((MacScreenHeight / 4) * 2 - 10) * MacScreenWidth
-								+ (MacScreenWidth / 2 - 8))
-								/ 8);
+	*lp = htonl(MacFrameBaseMac24Bit + (((MacScreenHeight / 4) * 2 - 10) * MacScreenWidth + (MacScreenWidth / 2 - 8)) / 8);
 
 	lp = (uint32 *)(ROMBaseHost + 0x10a2);
 	*lp = htonl(MacFrameBaseMac24Bit);
@@ -1096,16 +1090,10 @@ static bool patch_rom_classic(void)
 
 	// sad mac, mac icon
 	lp = (uint32 *)(ROMBaseHost + 0x118a);
-	*lp = htonl(MacFrameBaseMac24Bit
-							+ (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth
-								+ (MacScreenWidth / 2 - 16))
-								/ 8);
+	*lp = htonl(MacFrameBaseMac24Bit + (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth + (MacScreenWidth / 2 - 16)) / 8);
 	// sad mac, frown
 	lp = (uint32 *)(ROMBaseHost + 0x1198);
-	*lp = htonl(MacFrameBaseMac24Bit
-							+ (((MacScreenHeight / 4) * 2 - 19) * MacScreenWidth
-								+ (MacScreenWidth / 2 - 8))
-								/ 8);
+	*lp = htonl(MacFrameBaseMac24Bit + (((MacScreenHeight / 4) * 2 - 19) * MacScreenWidth + (MacScreenWidth / 2 - 8)) / 8);
 	wp = (uint16 *)(ROMBaseHost + 0x11b0);
 	*wp = htons(MacScreenWidth / 8);
 

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -1008,6 +1008,179 @@ static bool patch_rom_classic(void)
 	*wp++ = htons(M68K_EMUL_OP_IRQ);
 	*wp++ = htons(0x4a80);		// tst.l	d0
 	*wp = htons(0x67f4);		// beq		0x402be2
+
+
+	// Patch guest screen for an arbitary resolution
+	// We are going to steal the ROM space that runs RAM test
+	uint32 patchCodeBaseMac; 	// a stateful variable to keep track of the stolen location of the patched code in guest memory.
+	uint16* patchwp; 					// a stateful word pointer pointing to the patch code in host memory.
+	uint32* patchlp;					// a stateful long pointer pointing to the patch code in host memory.
+
+	uint32* lp;								// a statless long pointer
+
+	wp = (uint16 *)(ROMBaseHost + 0x5ca); // start to patch P_mInitVideoGlobal route
+	*wp++ = htons(0x4eb9); /* JSR */
+	lp = (uint32 *)wp;
+
+	const uint32 patchCodeOffset = 0x1d3e; // we steal P_mRamTest routine space
+	patchCodeBaseMac = ROMBaseMac + patchCodeOffset;
+	uint8* patchCodeBaseHost = ROMBaseHost + patchCodeOffset;
+	*lp++ = htonl(patchCodeBaseMac); // we JSR to this Mac address
+	wp = (uint16 *)lp;
+
+	patchwp = (uint16 *)(patchCodeBaseHost); // the host address for the patch
+	// MOVE.L $MacFrameBaseMac24Bit, ($ScrnBase)
+	*patchwp++ = htons(0x21fc); /* MOVE.L */
+	patchCodeBaseMac += 2;
+
+	patchlp = (uint32 *)patchwp;
+	*patchlp++ = htonl(MacFrameBaseMac24Bit);
+	patchCodeBaseMac += 4;
+
+	patchwp = (uint16 *)patchlp;
+	*patchwp++ = htons(0x0824); /* (ScrnBase) */
+	patchCodeBaseMac += 2;
+
+	*patchwp++ = htons(0x4e75); /* RTS */
+	patchCodeBaseMac += 2;
+	patchlp = (uint32 *)patchwp; // keep in sync
+
+	// continue to patch P_mInitVideoGlobal routine
+	wp = (uint16 *)(ROMBaseHost + 0x5d2);
+	*wp = htons(MacScreenWidth / 8);
+	wp = (uint16 *)(ROMBaseHost + 0x60a);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x60e);
+	*wp = htons(MacScreenWidth);
+
+	wp = (uint16 *)(ROMBaseHost + 0x8cc);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x8ce);
+	*wp = htons(MacScreenWidth);
+
+	// blink floppy, disk icon
+	lp = (uint32 *)(ROMBaseHost + 0xf4c);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth
+								 + (MacScreenWidth / 2 - 16))
+									 / 8);
+	// blink floppy, question mark
+	lp = (uint32 *)(ROMBaseHost + 0xf5e);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 10) * MacScreenWidth
+								+ (MacScreenWidth / 2 - 8))
+								/ 8);
+
+	lp = (uint32 *)(ROMBaseHost + 0x10a2);
+	*lp = htonl(MacFrameBaseMac24Bit);
+	wp = (uint16 *)(ROMBaseHost + 0x10a8);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x10ac);
+	*wp = htons(MacScreenWidth);
+	wp = (uint16 *)(ROMBaseHost + 0x10b0);
+	*wp = htons(MacScreenWidth / 8);
+	lp = (uint32 *)(ROMBaseHost + 0x10b4);
+	*lp = htonl(MacScreenWidth * MacScreenHeight / 8);// # of bytes in screen
+
+	// sad mac, mac icon
+	lp = (uint32 *)(ROMBaseHost + 0x118a);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 25) * MacScreenWidth
+								+ (MacScreenWidth / 2 - 16))
+								/ 8);
+	// sad mac, frown
+	lp = (uint32 *)(ROMBaseHost + 0x1198);
+	*lp = htonl(MacFrameBaseMac24Bit
+							+ (((MacScreenHeight / 4) * 2 - 19) * MacScreenWidth
+								+ (MacScreenWidth / 2 - 8))
+								/ 8);
+	wp = (uint16 *)(ROMBaseHost + 0x11b0);
+	*wp = htons(MacScreenWidth / 8);
+
+	// blink floppy and sadmac, position
+	wp = (uint16 *)(ROMBaseHost + 0x11d8);
+	*wp = htons(MacScreenWidth / 8);
+	wp = (uint16 *)(ROMBaseHost + 0x11ea);
+	*wp = htons(MacScreenWidth / 8);
+
+	// cursor handling
+	if (MacScreenWidth >= 1024)
+	{
+		wp = (uint16 *)(ROMBaseHost + 0x18dfe); // start to patch P_HideCursor routine
+		*wp++ = htons(0x4eb9); /* JSR */
+		lp = (uint32 *)wp;
+		*lp++ = htonl(patchCodeBaseMac);
+		wp = (uint16 *)lp;
+
+		*patchwp++ = htons(0x41f8); /* Lea.L (CrsrSave),A0 */
+		patchCodeBaseMac += 2;
+		*patchwp++ = htons(0x088c);
+		patchCodeBaseMac += 2;
+
+		*patchwp++ = htons(0x203c); /* MOVE.L #$x,D0 */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp;
+		*patchlp++ = htonl(MacScreenWidth / 8);
+		patchCodeBaseMac += 4;
+		patchwp = (uint16 *)patchlp;
+
+		*patchwp++ = htons(0x4e75); /* RTS */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp; // keep in sync
+	} else
+	{
+		// P_HideCursor
+		wp = (uint16 *)(ROMBaseHost + 0x18e02);
+		*wp = htons(0x7000 + (MacScreenWidth / 8));
+	} // end if (MacScreenWidth >= 1024)
+
+	wp = (uint16 *)(ROMBaseHost + 0x18e7a);
+	*wp = htons(MacScreenWidth - 32);
+	wp = (uint16 *)(ROMBaseHost + 0x18e80);
+	*wp = htons(MacScreenWidth - 32);
+	wp = (uint16 *)(ROMBaseHost + 0x18ea0);
+	*wp = htons(MacScreenHeight - 16);
+	wp = (uint16 *)(ROMBaseHost + 0x18ea6);
+	*wp = htons(MacScreenHeight);
+
+	if (MacScreenWidth >= 1024)
+	{
+		wp = (uint16 *)(ROMBaseHost + 0x18ec4); // start to patch P_ShowCursor routine
+		*wp++ = htons(0x4eb9); /* JSR */
+		lp = (uint32 *)wp;
+		*lp++ = htonl(patchCodeBaseMac);
+		wp = (uint16 *)lp;
+
+		*patchwp++ = htons(0x2a3c); /* MOVE.L #$x, D5 */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp;
+		*patchlp++ = htonl(MacScreenWidth / 8);
+		patchCodeBaseMac += 4;
+		patchwp = (uint16 *)patchlp;
+
+		*patchwp++ = htons(0xc2c5); /* MulU      D5, D1 */
+		patchCodeBaseMac += 2;
+
+		*patchwp++ = htons(0xd3c1); /* AddA.L    D1, A1 */
+		patchCodeBaseMac += 2;
+
+		*patchwp++ = htons(0x4e75); /* RTS */
+		patchCodeBaseMac += 2;
+		patchlp = (uint32 *)patchwp; // keep in sync
+	} else
+	{
+		wp = (uint16 *)(ROMBaseHost + 0x18ec4);
+		*wp = htons(0x7A00 + (MacScreenWidth / 8));
+	}// end if (MacScreenWidth >= 1024)
+
+	// set up screen bitmap
+	wp = (uint16 *)(ROMBaseHost + 0x18f9a);
+	*wp = htons(MacScreenHeight);
+	wp = (uint16 *)(ROMBaseHost + 0x18fa0);
+	*wp = htons(MacScreenWidth);
+	wp = (uint16 *)(ROMBaseHost + 0x18fb4);
+	*wp = htons(MacScreenHeight);
+
 	return true;
 }
 

--- a/BasiliskII/src/rom_patches.cpp
+++ b/BasiliskII/src/rom_patches.cpp
@@ -1116,8 +1116,7 @@ static bool patch_rom_classic(void)
 	*wp = htons(MacScreenWidth / 8);
 
 	// cursor handling
-	if (MacScreenWidth >= 1024)
-	{
+	if (MacScreenWidth >= 1024) {
 		// start to patch P_HideCursor routine
 		wp = (uint16 *)(ROMBaseHost + 0x18dfe);
 		*wp++ = htons(0x4eb9); /* JSR */
@@ -1140,8 +1139,7 @@ static bool patch_rom_classic(void)
 		*patchwp++ = htons(0x4e75); /* RTS */
 		patchCodeBaseMac += 2;
 		patchlp = (uint32 *)patchwp; // keep in sync
-	} else
-	{
+	} else {
 		// P_HideCursor
 		wp = (uint16 *)(ROMBaseHost + 0x18e02);
 		*wp = htons(0x7000 + (MacScreenWidth / 8));
@@ -1156,8 +1154,7 @@ static bool patch_rom_classic(void)
 	wp = (uint16 *)(ROMBaseHost + 0x18ea6);
 	*wp = htons(MacScreenHeight);
 
-	if (MacScreenWidth >= 1024)
-	{
+	if (MacScreenWidth >= 1024) {
 		// start to patch P_ShowCursor routine
 		wp = (uint16 *)(ROMBaseHost + 0x18ec4);
 		*wp++ = htons(0x4eb9); /* JSR */
@@ -1182,8 +1179,7 @@ static bool patch_rom_classic(void)
 		patchCodeBaseMac += 2;
 		// keep in sync
 		patchlp = (uint32 *)patchwp;
-	} else
-	{
+	} else {
 		wp = (uint16 *)(ROMBaseHost + 0x18ec4);
 		*wp = htons(0x7A00 + (MacScreenWidth / 8));
 	}// end if (MacScreenWidth >= 1024)

--- a/BasiliskII/src/uae_cpu/cpu_emulation.h
+++ b/BasiliskII/src/uae_cpu/cpu_emulation.h
@@ -37,6 +37,10 @@ extern uint32 ROMBaseMac;		// ROM base (Mac address space)
 extern uint8 *ROMBaseHost;		// ROM base (host address space)
 extern uint32 ROMSize;			// Size of ROM
 
+// For 24 Bit ROM, we maps the guest OS frame buffer address above 4MiB RAM
+// and ROM but less than 16 MiB.
+const uint32 MacFrameBaseMac24Bit = 0x00500000;
+
 #if !REAL_ADDRESSING && !DIRECT_ADDRESSING
 // If we are not using real or direct addressing, the Mac frame buffer gets
 // mapped to this location. The memory must be allocated by VideoInit().


### PR DESCRIPTION
- Added Mac SE 24 bit ROM screen patch from mini vMac.
  The guest OS resolution in System 6 can be defined
  at an arbitrary combination.
- Mac frame buffer base mapping is moved out from guest RAM.
  This creates more leg room for the host frame buffer.
- Enable System 6 vscreen support in SDL2. Passed build and test.
- Enable System 6 vscreen support in SDL1. Passed build and test.
- Eanble System 6 vscreen support in XWidnow. Passed build and test.

See my [screen cast demo here](https://youtu.be/aXzM8t_u3zI)

Travis is great to catch my first PR. It detected that I haven't patched for SDL1 or XWindow. 

See [Travis indicated the build is green](https://travis-ci.org/github/rickyzhang82/macemu/builds/708523844)

I personally tested all 3 combinations and make sure this PR works.

Signed-off-by: Ricky Zhang <rickyzhang@gmail.com>