### PR TITLE
Use openpty if possible

### DIFF
--- a/BasiliskII/src/Unix/configure.ac
+++ b/BasiliskII/src/Unix/configure.ac
@@ -601,7 +601,8 @@ dnl Check for headers and functions related to pty support (sshpty.c)
 dnl From openssh-3.2.2p1 configure.ac
 
 AC_CHECK_HEADERS(strings.h login.h sys/bsdtty.h sys/stat.h util.h pty.h)
-AC_CHECK_FUNCS(_getpty vhangup strlcpy)
+AC_SEARCH_LIBS([openpty], [util bsd])
+AC_CHECK_FUNCS(_getpty openpty vhangup strlcpy)
 
 case "$host" in
 *-*-hpux10.26)

--- a/SheepShaver/src/Unix/configure.ac
+++ b/SheepShaver/src/Unix/configure.ac
@@ -461,7 +461,8 @@ esac
 dnl Check for headers and functions related to pty support (sshpty.c)
 dnl From openssh-3.2.2p1 configure.ac
 AC_CHECK_HEADERS(strings.h login.h sys/bsdtty.h sys/stat.h util.h pty.h)
-AC_CHECK_FUNCS(_getpty vhangup strlcpy)
+AC_SEARCH_LIBS([openpty], [util bsd])
+AC_CHECK_FUNCS(_getpty openpty vhangup strlcpy)
 
 case "$host" in
 *-*-hpux10.26)


### PR DESCRIPTION
The code this affects in sshpty.c originally came from OpenSSH, which now uses openpty by preference when it's available. openpty is a BSD-ism, but it's been provided by glibc on Linux with the BSD semantics since 1998.

@fragglet - This might fix the problem that #190 (since reverted) was trying to address too?