### PR TITLE
Fix crash on aarch64 linux.

### DIFF
--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -95,7 +95,7 @@ typedef unsigned long vm_uintptr_t;
    don't get addresses above when the program is run on AMD64.
    NOTE: this is empirically determined on Linux/x86.  */
 #define MAP_BASE	0x10000000
-#else
+#elif !REAL_ADDRESSING
 /* linux does not implement any useful fallback behavior
    such as allocating the next available address
    and the first 4k of address space is marked unavailable
@@ -107,6 +107,8 @@ typedef unsigned long vm_uintptr_t;
    so we do this unconditionally on all platforms
    some of which use upwards of 64k pages, so lets start there, just in case */
 #define MAP_BASE	0x00010000
+#else /* must be 0x0 when REAL_ADDRESSING=1 */
+#define MAP_BASE	0x00000000
 #endif
 static char * next_address = (char *)MAP_BASE;
 #ifdef HAVE_MMAP_ANON

--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -98,14 +98,13 @@ typedef unsigned long vm_uintptr_t;
 #elif !REAL_ADDRESSING
 /* linux does not implement any useful fallback behavior
    such as allocating the next available address
-   and the first 4k of address space is marked unavailable
+   and the first 4k-64k of address space is marked unavailable
    for security reasons (see https://wiki.debian.org/mmap_min_addr)
    so we must start requesting after the first page
    (or we get a high 64bit address and break on aarch64)
 
    leaving NULL unmapped is a good idea anyway for debugging reasons
-   so we do this unconditionally on all platforms
-   some of which use upwards of 64k pages, so lets start there, just in case */
+   so we do this unconditionally on all platforms */
 #define MAP_BASE	0x00010000
 #else /* must be 0x0 when REAL_ADDRESSING=1 */
 #define MAP_BASE	0x00000000

--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -83,6 +83,10 @@ typedef unsigned long vm_uintptr_t;
 #define MAP_ANONYMOUS 0
 #endif
 
+/* NOTE: on linux MAP_32BIT is only implemented on AMD64
+   it is a null op on all other architectures
+   thus the MAP_BASE setting below is the only thing
+   ensuring low addresses on aarch64 for example */
 #define MAP_EXTRA_FLAGS (MAP_32BIT)
 
 #ifdef HAVE_MMAP_VM
@@ -92,7 +96,17 @@ typedef unsigned long vm_uintptr_t;
    NOTE: this is empirically determined on Linux/x86.  */
 #define MAP_BASE	0x10000000
 #else
-#define MAP_BASE	0x00000000
+/* linux does not implement any useful fallback behavior
+   such as allocating the next available address
+   and the first 4k of address space is marked unavailable
+   for security reasons (see https://wiki.debian.org/mmap_min_addr)
+   so we must start requesting after the first page
+   (or we get a high 64bit address and break on aarch64)
+
+   leaving NULL unmapped is a good idea anyway for debugging reasons
+   so we do this unconditionally on all platforms
+   some of which use upwards of 64k pages, so lets start there, just in case */
+#define MAP_BASE	0x00010000
 #endif
 static char * next_address = (char *)MAP_BASE;
 #ifdef HAVE_MMAP_ANON


### PR DESCRIPTION
Hi Basilisk II fails to start a VM on Debian aarch64, in my case a Raspi4.

With some printf debugging I discovered it is because MAP_BASE defaults to 0x0 which is unavailable for security reasons on recent kernels thus the memory allocator falls back on a standard allocation way up in 64bit address space, which fails the address sanity test and returns a misleading "not enough memory" error to the user.

```
$ build/nojit/BasiliskII-nojit 
Basilisk II V1.0 by Christian Bauer et al.
mmap next=(nil) got=0x7f9df00000
ERROR: Not enough free memory.
```

Removing the sanity check results in a VM crash so it would seem low addresses are in fact required for now.

The easy fix is to bump MAP_BASE up past the security/debug guard. I've added some comments explaining the issues involved and the choices made.

This is all a bit ugly and flaky and the real fix would be to make Basilisk II not require low addresses, but that's another patch for another day.

I have not touched the linux i386|FreeBSD|HAVE_LINKER_SCRIPT case as i don't know the issues there and i assume that case is working properly.

Resolves #188