### PR TITLE
Fix cxmon -Wformat-security error when building with gcc 10.2.0

### DIFF
--- a/cxmon/src/mon.cpp
+++ b/cxmon/src/mon.cpp
@@ -282,7 +282,7 @@ static void read_line(char *prompt)
 	static const unsigned INPUT_LENGTH = 256;
 	if (!input)
 		input = (char *)malloc(INPUT_LENGTH);
-	fprintf(monout, prompt);
+	fputs(prompt, monout);
 	fflush(monout);
 	fgets(in_ptr = input, INPUT_LENGTH, monin);
 	char *s = strchr(input, '\n');


### PR DESCRIPTION
This patch replaces a call to `fprintf()` with a non-format `prompt` argument with corresponding `fputs`. This resolves a compilation error with the latest GCC version. Also see [this FAQ](https://fedoraproject.org/wiki/Format-Security-FAQ).

```
./../../../cxmon/src/mon.cpp: In function 'void read_line(char*)':
./../../../cxmon/src/mon.cpp:285:24: error: format not a string literal and no format arguments [https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security>
  285 |  fprintf(monout, prompt);
      |                        ^
```

Let me know if you prefer this patch or `fprintf(monout, "%s", prompt);`.